### PR TITLE
[CC-27] Use Vocabulary Updates Where We Can

### DIFF
--- a/cc_licenses/templates/includes/about_cc.html
+++ b/cc_licenses/templates/includes/about_cc.html
@@ -2,7 +2,7 @@
 {# refactor this code and use "with" template tag in licenses_detail.html to pass header and text to these templates #}
 {# if this content will be modified through the django admin in the future #}
 
-<div id="about-cc-and-license" class="padding-bigger">
+<div id="about-cc-and-license" class="padding-bigger has-background-info-light">
   <h4 class="padding-bottom-normal is-vcentered b-header"><i class="info icon padding-right-normal"></i>About Creative Commons</h4>
   <p class="has-text-black padding-left-big">
     Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its 
@@ -18,9 +18,3 @@
     Creative Commons may be contacted at <a href="creativecommons.org">creativecommons.org</a>
   </p>
 </div>
-
-<style>
-  #about-cc-and-license {
-    background-color: rgb(209, 220, 241);
-  }
-</style>

--- a/cc_licenses/templates/includes/about_cc_and_license.html
+++ b/cc_licenses/templates/includes/about_cc_and_license.html
@@ -9,3 +9,4 @@
     their use to the fullest extent possible.
   </p>
 </div>
+ 

--- a/cc_licenses/templates/includes/about_cc_and_license.html
+++ b/cc_licenses/templates/includes/about_cc_and_license.html
@@ -1,4 +1,4 @@
-<div id="about-cc-and-license" class="padding-bigger">
+<div id="about-cc-and-license" class="padding-bigger has-background-info-light">
   <h4 class="padding-bottom-normal is-vcentered b-header"><i class="info icon padding-right-normal"></i>About the license and Creative Commons</h4>
   <p class="has-text-black padding-left-big">
     Creative Commons Corporation ("Creative Commons") is not a law firm and does not provide legal services 
@@ -9,9 +9,3 @@
     their use to the fullest extent possible.
   </p>
 </div>
-
-<style>
-  #about-cc-and-license {
-    background-color: rgb(209, 220, 241);
-  }
-</style>

--- a/cc_licenses/templates/includes/disclaimer.html
+++ b/cc_licenses/templates/includes/disclaimer.html
@@ -2,7 +2,7 @@
 {# refactor this code and use "with" template tag in licenses_detail.html to pass header and text to these templates #}
 {# if this content will be modified through the django admin in the future #}
 
-<div id="disclaimer-info-section" class="padding-bigger">
+<div id="disclaimer-info-section" class="padding-bigger has-background-info-light">
   <h4 class="padding-bottom-normal is-vcentered b-header"><i class="info icon padding-right-normal"></i>Disclaimer</h4>
   <p class="has-text-black padding-left-big">
     This deed highlights only some of the key features and terms of the actual license. It is not a license and 
@@ -14,9 +14,3 @@
     deed or the license that it summarizes does not create a lawyer-client or any other relationship.
   </p>
 </div>
-
-<style>
-  #disclaimer-info-section {
-    background-color: rgb(209, 220, 241);
-  }
-</style>

--- a/cc_licenses/templates/includes/red_alert.html
+++ b/cc_licenses/templates/includes/red_alert.html
@@ -1,6 +1,6 @@
 <div id="red_alert" class="padding-bigger margin-top-big">
   <p class="has-text-black body-big is-flex">
-    <i class="icon padding-right-big">info</i>
+    <i class="exclamation-circle icon padding-right-big"></i>
     Creative Commons has retired this legal tool and does not recommend that it be applied to works.
   </p>
 </div>

--- a/cc_licenses/templates/includes/use_of_licenses.html
+++ b/cc_licenses/templates/includes/use_of_licenses.html
@@ -1,4 +1,5 @@
- <div id="about-cc-and-license" class="padding-bigger margin-top-bigger has-background-info-light">
+{# For JS Toggling Feature for Consideration Sections - See licenses_detail.html #}
+<div id="about-cc-and-license" class="padding-bigger margin-top-bigger has-background-info-light">
   <h4 class="level is-vcentered b-header">Using Creative Commons Public Licenses</h4>
   <p class="has-text-black body-big">
     Creative Commons public licenses provide a standard set of terms and conditions that creators
@@ -33,4 +34,10 @@
   </div>
 </div>
 
-{# For JS Toggling Feature for Consideration Sections - See licenses_detail.html #}
+<style>
+  .has-background-info-light .divider {
+      margin-left: -2rem;
+      width: calc(100% + 4rem);
+      background-color: #b0b0b0;
+  }
+</style>

--- a/cc_licenses/templates/includes/use_of_licenses.html
+++ b/cc_licenses/templates/includes/use_of_licenses.html
@@ -1,4 +1,4 @@
- <div id="about-cc-and-license" class="padding-bigger margin-top-bigger has-background-Info">
+ <div id="about-cc-and-license" class="padding-bigger margin-top-bigger has-background-info-light">
   <h4 class="level is-vcentered b-header">Using Creative Commons Public Licenses</h4>
   <p class="has-text-black body-big">
     Creative Commons public licenses provide a standard set of terms and conditions that creators


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number] by @[issue author]

## Description
<!-- Concisely describe what the pull request does. -->
https://caktus.atlassian.net/browse/CC-27

- `has-background-info-light` has been added to info divs. `style` tags has been removed.
- `exclamation-circle` icon has been added to `red-alert` div. `info` icon has been removed.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
