### PR TITLE
[CC-54] Render date when legal code translation has been last updated

### DIFF
--- a/licenses/templates/legalcode_40_page.html
+++ b/licenses/templates/legalcode_40_page.html
@@ -10,7 +10,7 @@
       Version {{ legalcode.license.version }} &#8226;
       See the <a href="#">errata page</a> for any corrections and the date of change
       {% if legalcode.translation_last_update %}
-        &#8226 Translation published {{ legalcode.translation_last_update|date:'Y/m/d' }}
+        &#8226; Translation published {{ legalcode.translation_last_update|date:'Y/m/d' }}
       {% endif %}
     </div>
     <div class="column">

--- a/licenses/templates/legalcode_40_page.html
+++ b/licenses/templates/legalcode_40_page.html
@@ -8,8 +8,10 @@
   <div class="column columns padding-vertical-normal">
     <div class="column is-three-quarters padding-top-normal">
       Version {{ legalcode.license.version }} &#8226;
-      See the <a href="#">errata page</a> for any corrections and the date of change &#8226
-      Translation published 2020/XX/XX
+      See the <a href="#">errata page</a> for any corrections and the date of change
+      {% if legalcode.translation_last_update %}
+        &#8226 Translation published {{ legalcode.translation_last_update|date:'Y/m/d' }}
+      {% endif %}
     </div>
     <div class="column">
       <button id="next-btn" class="button tiny is-pulled-{% end %}" data-href="{{ legalcode.deed_url }}">{% trans "See the deed" %}</button>


### PR DESCRIPTION
This PR updates the `legalcode_40` template to display the date when the translation was last updated. This part was originally hard coded while we focused on page styling. Currently no legalcode instance has a populated `datetime` field for `legalcode.translation_last_update`. However this should not be the case once cc31 is merged into develop which deals with pulling translations from transifex. 