### PR TITLE
[CC-31] Create branch when transifex updated

### DIFF
--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -221,3 +221,6 @@ TRANSIFEX = {
     "PROJECT_SLUG": "CC",
     "API_TOKEN": os.getenv("TRANSIFEX_API_TOKEN", "missing"),
 }
+
+# The git branch where the official, approved, used in production translations are.
+OFFICIAL_GIT_BRANCH = "develop"

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase, override_settings
 
-from i18n.utils import get_translation_object
+from i18n.utils import get_translation_object, save_content_as_pofile_and_mofile
 
 TEST_POFILE = os.path.join(
     os.path.dirname(__file__), "locales", "es_test_4.0", "LC_MESSAGES", "test-4.0.po"
@@ -25,3 +25,16 @@ class TranslationTest(TestCase):
         )
         mock_trans.assert_called_with("code")
         self.assertEqual(translation_object, result)
+
+
+class PofileTest(TestCase):
+    def test_save_content_as_pofile_and_mofile(self):
+        path = "/foo/bar.po"
+        content = b"xxxxxyyyyy"
+        with mock.patch("i18n.utils.polib") as mock_polib:
+            return_value = save_content_as_pofile_and_mofile(path, content)
+        self.assertEqual(("/foo/bar.po", "/foo/bar.mo"), return_value)
+        mock_polib.pofile.assert_called_with(pofile=content.decode(), encoding="utf-8")
+        pofile = mock_polib.pofile.return_value
+        pofile.save.assert_called_with(path)
+        pofile.save_as_mofile.assert_called_with("/foo/bar.mo")

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import re
 from contextlib import contextmanager
 
 import polib
@@ -107,6 +108,15 @@ def active_translation(translation: DjangoTranslation):
         del _active.value
     else:
         _active.value = previous_translation
+
+
+def save_content_as_pofile_and_mofile(path: str, content: bytes):
+    """Returns pofile_abspath, mofile_abspath"""
+    pofile = polib.pofile(pofile=content.decode(), encoding="utf-8")
+    pofile.save(path)
+    mofilepath = re.sub(r"\.po$", ".mo", path)
+    pofile.save_as_mofile(mofilepath)
+    return (path, mofilepath)
 
 
 def get_pofile_content(pofile: polib.POFile) -> str:

--- a/licenses/git_utils.py
+++ b/licenses/git_utils.py
@@ -1,0 +1,41 @@
+import git
+
+
+def setup_local_branch(repo: git.Repo, branch_name: str, parent_branch_name: str):
+    """
+    Ensure we have a local branch named 'branch_name'.
+    Pull from upstream ('origin'), or create as a branch from parent_branch_name.
+    If there's an upstream one, pull from it to make sure we're up to date.
+    Check it out.
+    """
+    # is there already a branch?
+    origin = repo.remotes.origin
+    origin.fetch()
+    if not hasattr(repo.branches, branch_name):
+        # Not locally, maybe upstream
+        if hasattr(origin.refs, branch_name):
+            repo.create_head(branch_name, f"origin/{branch_name}")
+        else:
+            # Nope, need to create from scratch
+            print("create from scratch")
+            parent_branch = getattr(origin.refs, parent_branch_name)
+            repo.create_head(branch_name, parent_branch)
+    else:
+        print("local already exists")
+    branch = getattr(repo.heads, branch_name)
+    branch.checkout()
+    # Make sure local branch is up to date if there's an upstream branch
+    if hasattr(origin.refs, branch_name):
+        origin.pull(f"{branch_name}:{branch_name}")
+
+
+def commit_and_push_changes(repo: git.Repo, branch_name: str, commit_msg: str):
+    """Commit new translation changes to current branch, and push upstream"""
+    index = repo.index
+    index.commit(commit_msg)
+    results = repo.remotes.origin.push(f"{branch_name}:{branch_name}")
+    if len(results) == 0:
+        raise Exception("PUSH FAILED COMPLETELY - add more info to this message")
+    for result in results:
+        if git.PushInfo.ERROR & result.flags:
+            raise Exception(f"PUSH FAILED {result.summary}")

--- a/licenses/git_utils.py
+++ b/licenses/git_utils.py
@@ -29,10 +29,12 @@ def setup_local_branch(repo: git.Repo, branch_name: str, parent_branch_name: str
         origin.pull(f"{branch_name}:{branch_name}")
 
 
-def commit_and_push_changes(repo: git.Repo, branch_name: str, commit_msg: str):
+def commit_and_push_changes(repo: git.Repo, commit_msg: str):
     """Commit new translation changes to current branch, and push upstream"""
     index = repo.index
     index.commit(commit_msg)
+    current_branch = repo.head.reference
+    branch_name = current_branch.name
     results = repo.remotes.origin.push(f"{branch_name}:{branch_name}")
     if len(results) == 0:
         raise Exception("PUSH FAILED COMPLETELY - add more info to this message")

--- a/licenses/management/commands/check_for_translation_updates.py
+++ b/licenses/management/commands/check_for_translation_updates.py
@@ -1,8 +1,12 @@
 from django.core.management import BaseCommand
 
-from licenses.transifex import check_for_translation_updates
+from licenses.transifex import transifex_helper
+
+TOP_BRANCH = "develop"
+
+branch_name = "test_branch"
 
 
 class Command(BaseCommand):
     def handle(self, **options):
-        check_for_translation_updates()
+        transifex_helper.check_for_translation_updates()

--- a/licenses/management/commands/check_for_translation_updates.py
+++ b/licenses/management/commands/check_for_translation_updates.py
@@ -1,4 +1,4 @@
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, call_command
 
 from licenses.transifex import TransifexHelper
 
@@ -9,4 +9,12 @@ branch_name = "test_branch"
 
 class Command(BaseCommand):
     def handle(self, **options):
-        TransifexHelper().check_for_translation_updates()
+        branches_updated = TransifexHelper().check_for_translation_updates()
+
+        # run collectstatic if we're going to publish
+        if branches_updated:
+            call_command("collectstatic", interactive=False)
+
+        for branch_name in branches_updated:
+            # Update the HTML files, commit, and push
+            call_command("publish", branch_name=branch_name)

--- a/licenses/management/commands/check_for_translation_updates.py
+++ b/licenses/management/commands/check_for_translation_updates.py
@@ -14,7 +14,9 @@ class Command(BaseCommand):
         # run collectstatic if we're going to publish
         if branches_updated:
             call_command("collectstatic", interactive=False)
+            print("Ran collectstatic")
 
         for branch_name in branches_updated:
             # Update the HTML files, commit, and push
             call_command("publish", branch_name=branch_name)
+            print(f"Updated HTML files for {branch_name}, updated branch, and pushed")

--- a/licenses/management/commands/check_for_translation_updates.py
+++ b/licenses/management/commands/check_for_translation_updates.py
@@ -1,6 +1,6 @@
 from django.core.management import BaseCommand
 
-from licenses.transifex import transifex_helper
+from licenses.transifex import TransifexHelper
 
 TOP_BRANCH = "develop"
 
@@ -9,4 +9,4 @@ branch_name = "test_branch"
 
 class Command(BaseCommand):
     def handle(self, **options):
-        transifex_helper.check_for_translation_updates()
+        TransifexHelper().check_for_translation_updates()

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -3,7 +3,7 @@ import sys
 from argparse import ArgumentParser
 
 from bs4 import BeautifulSoup, Tag
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, call_command
 from polib import POEntry, POFile
 
 from i18n import DEFAULT_LANGUAGE_CODE
@@ -192,6 +192,8 @@ class Command(BaseCommand):
                     os.makedirs(dir)
                 pofile.save(po_filename)
                 print(f"Created {po_filename}")
+        # Compile the .po files to .mo files
+        call_command("compilemessages")
 
     def import_by_40_license_html(self, content, license_code, language_code):
         """

--- a/licenses/management/commands/publish.py
+++ b/licenses/management/commands/publish.py
@@ -63,7 +63,8 @@ def git_commit_and_push(branch: str):
 def pull_translations_branches():
     """Git pulls branches in cc-licenses-data to update local git registry"""
     subprocess.run(
-        ["git", "checkout", "develop"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
+        ["git", "checkout", settings.OFFICIAL_GIT_BRANCH],
+        cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY,
     )
     return subprocess.run(
         ["git", "pull"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY

--- a/licenses/management/commands/publish.py
+++ b/licenses/management/commands/publish.py
@@ -3,85 +3,22 @@ import subprocess
 from argparse import ArgumentParser
 from shutil import rmtree
 
+import git
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django_distill.distill import urls_to_distill
 from django_distill.errors import DistillError
 from django_distill.renderer import render_to_dir
 
+from licenses.git_utils import commit_and_push_changes, setup_local_branch
 from licenses.utils import cleanup_current_branch_output, strip_list_whitespace
 
 
-def check_if_build_to_push(branch: str):
-    """Navigates to a branch and checks the status of the branch
-
-    Returns:
-        True if files need to be committed
-        False if the working tree is clean
-    """
-    subprocess.run(
-        ["git", "checkout", f"{branch}"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
-    )
-    status = (
-        subprocess.check_output(
-            ["git", "status"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
-        )
-        .decode()
-        .splitlines()
-    )
-    if "nothing to commit, working tree clean" in status:
-        return False
-    return True
-
-
-def git_on_branch_and_pull(branch: str):
-    """Commands to checkout and pull from a branch"""
-    subprocess.run(
-        ["git", "checkout", f"{branch}"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
-    )
-    return subprocess.run(
-        ["git", "pull", "origin", f"{branch}"],
-        cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY,
-    )
-
-
-def git_commit_and_push(branch: str):
-    """Command to git checkout, commit, and push branch"""
-    subprocess.run(
-        ["git", "add", "build/"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
-    )
-    subprocess.run(
-        ["git", "commit", "-m", f"{branch}"],
-        cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY,
-    )
-    return subprocess.run(
-        ["git", "push", "origin", f"{branch}"],
-        cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY,
-    )
-
-
-def pull_translations_branches():
-    """Git pulls branches in cc-licenses-data to update local git registry"""
-    subprocess.run(
-        ["git", "checkout", settings.OFFICIAL_GIT_BRANCH],
-        cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY,
-    )
-    return subprocess.run(
-        ["git", "pull"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
-    )
-
-
 def list_open_branches():
-    """List of open branches in cc-licenses-data repo
+    """List of names of open local branches in cc-licenses-data repo
     """
-    pull_translations_branches()
-    branches = (
-        subprocess.check_output(
-            ["git", "branch", "--list"], cwd=settings.TRANSLATION_REPOSITORY_DIRECTORY
-        )
-        .decode()
-        .splitlines()
-    )
+    with git.Repo(settings.TRANSLATION_REPOSITORY_DIRECTORY) as repo:
+        branches = [head.name for head in repo.branches]
     print("\n\nWhich branch are we publishing to?\n")
     for b in branches:
         print(b)
@@ -140,13 +77,13 @@ class Command(BaseCommand):
 
     def publish_branch(self, branch: str):
         """Workflow for publishing a single branch"""
-        git_on_branch_and_pull(branch)
-        self.run_django_distill()
-        build_to_push = check_if_build_to_push(branch)
-        if build_to_push:
-            git_commit_and_push(branch)
-        else:
-            print(f"\n{branch} build dir is up to date.\n")
+        with git.Repo(settings.TRANSLATION_REPOSITORY_DIRECTORY) as repo:
+            setup_local_branch(repo, branch, settings.OFFICIAL_GIT_BRANCH)
+            self.run_django_distill()
+            if repo.dirty():
+                commit_and_push_changes(repo, branch, "Updated built HTML files")
+            else:
+                print(f"\n{branch} build dir is up to date.\n")
 
     def publish_all(self):
         """Workflow for checking branches and updating their build dir

--- a/licenses/tests/test_git_utils.py
+++ b/licenses/tests/test_git_utils.py
@@ -1,0 +1,123 @@
+from unittest import mock
+
+import git
+from django.test import TestCase, override_settings
+
+from licenses.git_utils import commit_and_push_changes, setup_local_branch
+
+
+class Dummy:
+    """
+    Just an empty object we can set attributes on,
+    but that won't make them up as a Mock would.
+    """
+
+
+@override_settings(TRANSLATION_REPOSITORY_DIRECTORY="/trans/repo")
+class SetupLocalBranchTest(TestCase):
+    def test_branch_exists_nowhere(self):
+        mock_repo = mock.MagicMock()
+        mock_repo.branches = Dummy()  # won't have branchname as an attribute
+        mock_repo.heads = Dummy()
+        mock_branch = mock.MagicMock()
+        setattr(mock_repo.heads, "ourbranch", mock_branch)
+        mock_origin = mock.MagicMock()
+        mock_origin.refs = Dummy()  # similar
+        mock_parent_branch = mock.MagicMock()
+        setattr(mock_origin.refs, "parentbranch", mock_parent_branch)
+        mock_repo.remotes.origin = mock_origin
+
+        setup_local_branch(mock_repo, "ourbranch", "parentbranch")
+
+        mock_origin.fetch.assert_called_with()
+        mock_repo.create_head.assert_called_with("ourbranch", mock_parent_branch)
+        mock_origin.pull.assert_not_called()
+        mock_branch.checkout.assert_called_with()
+
+    def test_branch_exists_upstream(self):
+        mock_repo = mock.MagicMock()
+        mock_repo.branches = Dummy()  # won't have branchname as an attribute
+        mock_origin = mock.MagicMock()
+        mock_origin.refs = Dummy()  # similar
+        mock_branch = mock.MagicMock()
+        setattr(mock_repo.heads, "ourbranch", mock_branch)
+        mock_upstream_branch = mock.MagicMock()
+        setattr(mock_origin.refs, "ourbranch", mock_upstream_branch)
+        mock_parent_branch = mock.MagicMock()
+        setattr(mock_origin.refs, "parentbranch", mock_parent_branch)
+        mock_repo.remotes.origin = mock_origin
+
+        setup_local_branch(mock_repo, "ourbranch", "parentbranch")
+
+        mock_origin.fetch.assert_called_with()
+        mock_repo.create_head.assert_called_with("ourbranch", "origin/ourbranch")
+        mock_origin.pull.assert_called_with("ourbranch:ourbranch")
+        mock_branch.checkout.assert_called_with()
+
+    def test_branch_exists_locally(self):
+        mock_branch = mock.MagicMock()
+        mock_repo = mock.MagicMock()
+        setattr(mock_repo.heads, "ourbranch", mock_branch)
+        mock_repo.branches = Dummy()
+        setattr(mock_repo.branches, "ourbranch", mock_branch)
+        mock_origin = mock.MagicMock()
+        mock_origin.refs = Dummy()  # similar
+        mock_branch = mock.MagicMock()
+        setattr(mock_repo.heads, "ourbranch", mock_branch)
+        mock_upstream_branch = mock.MagicMock()
+        setattr(mock_origin.refs, "ourbranch", mock_upstream_branch)
+        mock_parent_branch = mock.MagicMock()
+        setattr(mock_origin.refs, "parentbranch", mock_parent_branch)
+        mock_repo.remotes.origin = mock_origin
+
+        setup_local_branch(mock_repo, "ourbranch", "parentbranch")
+
+        mock_origin.fetch.assert_called_with()
+        mock_repo.create_head.assert_not_called()
+        mock_origin.pull.assert_called_with("ourbranch:ourbranch")
+        mock_branch.checkout.assert_called_with()
+
+
+@override_settings(TRANSLATION_REPOSITORY_DIRECTORY="/trans/repo")
+class CommitAndPushChangesTest(TestCase):
+    def test_no_push_results_failure(self):
+        """For bad failures, push returns an empty list"""
+        branch_name = "ourbranch"
+        commit_msg = "commit message"
+        mock_repo = mock.MagicMock()
+        mock_repo.remotes.origin.push.return_value = []
+
+        with self.assertRaisesMessage(Exception, "PUSH FAILED COMPLETELY"):
+            commit_and_push_changes(mock_repo, branch_name, commit_msg)
+
+        mock_repo.index.commit.assert_called_with(commit_msg)
+        mock_repo.remotes.origin.push.assert_called_with(f"{branch_name}:{branch_name}")
+
+    def test_good_push_results(self):
+        branch_name = "ourbranch"
+        commit_msg = "commit message"
+        mock_repo = mock.MagicMock()
+        mock_result = mock.MagicMock()
+        mock_result.summary = "push result"
+        mock_result.flags = 0
+        mock_repo.remotes.origin.push.return_value = [mock_result]
+
+        commit_and_push_changes(mock_repo, branch_name, commit_msg)
+
+        mock_repo.index.commit.assert_called_with(commit_msg)
+        mock_repo.remotes.origin.push.assert_called_with(f"{branch_name}:{branch_name}")
+
+    def test_bad_push_results(self):
+        branch_name = "ourbranch"
+        commit_msg = "commit message"
+        mock_repo = mock.MagicMock()
+        mock_result = mock.MagicMock()
+        mock_result.summary = "push result"
+        mock_result.flags = git.PushInfo.ERROR
+        mock_repo.remotes.origin.push.return_value = [mock_result]
+
+        with self.assertRaisesMessage(Exception, "PUSH FAILED push result"):
+            commit_and_push_changes(mock_repo, branch_name, commit_msg)
+
+        mock_repo.index.commit.assert_called_with(commit_msg)
+        mock_repo.remotes.origin.push.assert_called_with(f"{branch_name}:{branch_name}")

--- a/licenses/tests/test_git_utils.py
+++ b/licenses/tests/test_git_utils.py
@@ -86,9 +86,10 @@ class CommitAndPushChangesTest(TestCase):
         commit_msg = "commit message"
         mock_repo = mock.MagicMock()
         mock_repo.remotes.origin.push.return_value = []
+        mock_repo.head.reference.name = branch_name
 
         with self.assertRaisesMessage(Exception, "PUSH FAILED COMPLETELY"):
-            commit_and_push_changes(mock_repo, branch_name, commit_msg)
+            commit_and_push_changes(mock_repo, commit_msg)
 
         mock_repo.index.commit.assert_called_with(commit_msg)
         mock_repo.remotes.origin.push.assert_called_with(f"{branch_name}:{branch_name}")
@@ -101,8 +102,9 @@ class CommitAndPushChangesTest(TestCase):
         mock_result.summary = "push result"
         mock_result.flags = 0
         mock_repo.remotes.origin.push.return_value = [mock_result]
+        mock_repo.head.reference.name = branch_name
 
-        commit_and_push_changes(mock_repo, branch_name, commit_msg)
+        commit_and_push_changes(mock_repo, commit_msg)
 
         mock_repo.index.commit.assert_called_with(commit_msg)
         mock_repo.remotes.origin.push.assert_called_with(f"{branch_name}:{branch_name}")
@@ -115,9 +117,10 @@ class CommitAndPushChangesTest(TestCase):
         mock_result.summary = "push result"
         mock_result.flags = git.PushInfo.ERROR
         mock_repo.remotes.origin.push.return_value = [mock_result]
+        mock_repo.head.reference.name = branch_name
 
         with self.assertRaisesMessage(Exception, "PUSH FAILED push result"):
-            commit_and_push_changes(mock_repo, branch_name, commit_msg)
+            commit_and_push_changes(mock_repo, commit_msg)
 
         mock_repo.index.commit.assert_called_with(commit_msg)
         mock_repo.remotes.origin.push.assert_called_with(f"{branch_name}:{branch_name}")

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -1,11 +1,13 @@
-from pprint import pprint
+import datetime
 from unittest import mock
 from unittest.mock import MagicMock, call
 
 import git
 import polib
 import requests
+from django.conf import settings
 from django.test import TestCase, override_settings
+from django.utils.timezone import utc
 
 from i18n import DEFAULT_LANGUAGE_CODE
 from licenses.tests.factories import LegalCodeFactory, LicenseFactory
@@ -250,36 +252,234 @@ msgstr "Attribution-NoDerivatives 4.0 International"
             ]
             result = self.helper.get_transifex_resource_stats()
         calls = mock_request25.call_args_list
-        self.assertEqual([
-            call('get', 'organizations/org/projects/proj/resources/'),
-            call('get', 'organizations/org/projects/proj/resources/slug0'),
-        ], calls)
+        self.assertEqual(
+            [
+                call("get", "organizations/org/projects/proj/resources/"),
+                call("get", "organizations/org/projects/proj/resources/slug0"),
+            ],
+            calls,
+        )
         self.assertEqual({"slug0": "stats1"}, result)
 
 
+@override_settings(TRANSLATION_REPOSITORY_DIRECTORY="/trans/repo",)
 class CheckForTranslationUpdatesTest(TestCase):
     def test_check_for_translation_updates_with_dirty_repo(self):
-        helper = TransifexHelper()
         mock_repo = MagicMock()
+        mock_repo.__str__.return_value = "mock_repo"
         mock_repo.is_dirty.return_value = True
-        with mpo(git, "Repo") as mock_Repo:
-            mock_Repo.return_value = mock_repo
-
+        with mock.patch.object(git, "Repo") as mock_Repo:
+            mock_Repo.return_value.__enter__.return_value = mock_repo
+            helper = TransifexHelper()
             with self.assertRaisesMessage(Exception, "is dirty. We cannot continue."):
                 helper.check_for_translation_updates()
 
     def test_check_for_translation_updates_with_no_legalcodes(self):
-        helper = TransifexHelper()
+        mock_repo = MagicMock()
+        mock_repo.__str__.return_value = "mock_repo"
+        mock_repo.is_dirty.return_value = False
+        with mock.patch.object(git, "Repo") as mock_Repo:
+            mock_Repo.return_value.__enter__.return_value = mock_repo
+            with mock.patch.object(
+                TransifexHelper, "get_transifex_resource_stats"
+            ) as mock_get_transifex_resource_stats:
+                mock_get_transifex_resource_stats.return_value = {}
+                helper = TransifexHelper()
+                helper.check_for_translation_updates()
+
+    def test_check_for_translation_updates_first_time(self):
+        # We don't have a 'translation_last_update' yet to compare to.
+        language_code = "zh-Hans"
+        license = LicenseFactory(version="4.0", license_code="by-nd")
+        legalcode = LegalCodeFactory(
+            license=license, language_code=language_code, translation_last_update=None
+        )
+        resource_slug = license.resource_slug
+
         mock_repo = MagicMock()
         mock_repo.is_dirty.return_value = False
-        print(f"mock_repo = {mock_repo}")
-        print(f"mock_repo.is_dirty = {mock_repo.is_dirty}")
-        # mock_RepoClass = MagicMock(side_effect=mock_repo)
-        # print(f"mock_RepoClass = {mock_RepoClass}")
-        with mock.patch("licenses.transifex.git") as mock_git:
-            print(f"mock_git = {mock_git}")
-            mock_git.Repo.return_value = mock_repo
-            helper.check_for_translation_updates()
+        with mock.patch.object(git, "Repo") as mock_Repo:
+            # 'Repo' is used as a context manager, make it return our mock repo.
+            mock_Repo.return_value.__enter__.return_value = mock_repo
+            with mock.patch.object(
+                TransifexHelper, "get_transifex_resource_stats"
+            ) as mock_get_transifex_resource_stats:
+                mock_get_transifex_resource_stats.return_value = {
+                    resource_slug: {
+                        language_code: {
+                            "translated": {"last_activity": "2007-01-25T12:00:00Z",}
+                        }
+                    }
+                }
+                helper = TransifexHelper()
+                helper.check_for_translation_updates()
+        # We should have set the 'translation_last_update'
+        legalcode.refresh_from_db()
+        self.assertEqual(
+            datetime.datetime(2007, 1, 25, 12, 0, 0, tzinfo=utc),
+            legalcode.translation_last_update,
+        )
+
+    def test_check_for_translation_updates_unchanged(self):
+        # The translation update timestamp has not changed
+        language_code = "zh-Hans"
+        license = LicenseFactory(version="4.0", license_code="by-nd")
+        legalcode = LegalCodeFactory(
+            license=license,
+            language_code=language_code,
+            translation_last_update=datetime.datetime(
+                2007, 1, 25, 12, 0, 0, tzinfo=utc
+            ),
+        )
+        resource_slug = license.resource_slug
+
+        class DummyRepo:
+            def __init__(self, path):
+                self.index = MagicMock()
+                self.remotes = MagicMock()
+
+            def __str__(self):
+                return "a dummy repo"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a, **k):
+                pass
+
+            def is_dirty(self):
+                return False
+
+        timestamp = "2007-01-25T12:00:00Z"
+
+        mock_repo = MagicMock()
+        mock_repo.is_dirty.return_value = False
+        with mock.patch.object(git, "Repo", new=DummyRepo):
+            # 'Repo' is used as a context manager, make it return our mock repo.
+            # mock_Repo.return_value.__enter__.return_value = mock_repo
+            with mock.patch.object(
+                TransifexHelper, "get_transifex_resource_stats"
+            ) as mock_get_transifex_resource_stats:
+                mock_get_transifex_resource_stats.return_value = {
+                    resource_slug: {
+                        language_code: {"translated": {"last_activity": timestamp,}}
+                    }
+                }
+                helper = TransifexHelper()
+                with mpo(helper.api_v20, "get") as mock_get:
+                    mock_get.return_value.content = "# empty po file".encode()
+                    with mock.patch(
+                        "licenses.transifex.setup_local_branch"
+                    ) as mock_setup_local_branch:
+                        with mock.patch(
+                            "licenses.transifex.commit_and_push_changes"
+                        ) as mock_commit_and_push_changes:
+                            helper.check_for_translation_updates()
+
+        # Nothing changed, so...nothing should have been done.
+        mock_setup_local_branch.assert_not_called()
+        mock_commit_and_push_changes.assert_not_called()
+        mock_get.assert_not_called()
+        self.assertEqual([], helper.legalcodes_to_update)
+        # We should not have set the 'translation_last_update'
+        legalcode.refresh_from_db()
+        self.assertEqual(
+            datetime.datetime(2007, 1, 25, 12, 0, 0, tzinfo=utc),
+            legalcode.translation_last_update,
+        )
+
+    def test_check_for_translation_updates_changed(self):
+        # 'translation' is newer than translation_last_update
+        language_code = "zh-Hans"
+        license = LicenseFactory(version="4.0", license_code="by-nd")
+        legalcode = LegalCodeFactory(
+            license=license,
+            language_code=language_code,
+            translation_last_update=datetime.datetime(
+                2007, 1, 25, 12, 0, 0, tzinfo=utc
+            ),
+        )
+        resource_slug = license.resource_slug
+
+        dummy_repo = None
+
+        class DummyRepo:
+            def __init__(self, path):
+                nonlocal dummy_repo
+                dummy_repo = self
+                self.index = MagicMock()
+                self.remotes = MagicMock()
+
+            def __str__(self):
+                return "a dummy repo"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a, **k):
+                pass
+
+            def is_dirty(self):
+                return False
+
+        timestamp = "2020-09-30T13:11:52Z"
+
+        mock_repo = MagicMock()
+        mock_repo.is_dirty.return_value = False
+        with mock.patch.object(git, "Repo", new=DummyRepo):
+            # 'Repo' is used as a context manager, make it return our mock repo.
+            # mock_Repo.return_value.__enter__.return_value = mock_repo
+            with mock.patch.object(
+                TransifexHelper, "get_transifex_resource_stats"
+            ) as mock_get_transifex_resource_stats:
+                mock_get_transifex_resource_stats.return_value = {
+                    resource_slug: {
+                        language_code: {"translated": {"last_activity": timestamp,}}
+                    }
+                }
+                helper = TransifexHelper()
+                with mpo(helper.api_v20, "get") as mock_get:
+                    mock_get.return_value.content = "# empty po file".encode()
+                    with mock.patch(
+                        "licenses.transifex.setup_local_branch"
+                    ) as mock_setup_local_branch:
+                        with mock.patch(
+                            "licenses.transifex.commit_and_push_changes"
+                        ) as mock_commit_and_push_changes:
+                            with mock.patch.object(
+                                polib.POFile, "save"
+                            ) as mock_pofile_save:
+                                with mock.patch.object(
+                                    polib.POFile, "save_as_mofile"
+                                ) as mock_mofile_save:
+                                    helper.check_for_translation_updates()
+
+        mock_pofile_save.assert_called_with(
+            "/trans/repo/legalcode/zh_Hans/LC_MESSAGES/by-nd_40.po"
+        )
+        mock_mofile_save.assert_called_with(
+            "/trans/repo/legalcode/zh_Hans/LC_MESSAGES/by-nd_40.mo"
+        )
+        mock_setup_local_branch.assert_called_with(
+            dummy_repo, f"cc4-{language_code}".lower(), settings.OFFICIAL_GIT_BRANCH
+        )
+        # commit_and_push_changes(repo, branch_name, commit_msg)
+        mock_commit_and_push_changes.assert_called_with(
+            dummy_repo,
+            f"cc4-{language_code}".lower(),
+            f"Translation changes downloaded {timestamp} from Transifex",
+        )
+        mock_get.assert_called_with(
+            "https://www.transifex.com/api/2//project/CC/resource/by-nd_40/translation/zh-Hans/?mode=translator&file=PO"
+        )
+        self.assertEqual([legalcode], helper.legalcodes_to_update)
+
+        # We should have set the 'translation_last_update'
+        legalcode.refresh_from_db()
+        self.assertEqual(
+            datetime.datetime(2020, 9, 30, 13, 11, 52, tzinfo=utc),
+            legalcode.translation_last_update,
+        )
 
 
 class TestTransifexAuthRequests(TestCase):

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -7,9 +7,10 @@ import polib
 import requests
 from django.conf import settings
 from django.test import TestCase, override_settings
-from django.utils.timezone import utc
+from django.utils.timezone import now, utc
 
 from i18n import DEFAULT_LANGUAGE_CODE
+from licenses.models import TranslationBranch
 from licenses.tests.factories import LegalCodeFactory, LicenseFactory
 from licenses.transifex import TransifexAuthRequests, TransifexHelper
 
@@ -26,6 +27,26 @@ TEST_TRANSIFEX_SETTINGS = {
 # for  'mock.patch' and 'mock.patch.object'
 mp = mock.patch
 mpo = mock.patch.object
+
+
+class DummyRepo:
+    def __init__(self, path):
+        self.index = MagicMock()
+        self.remotes = MagicMock()
+        self.branches = MagicMock()
+        self.heads = MagicMock()
+
+    # def __str__(self):
+    #     return "a dummy repo"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a, **k):
+        pass
+
+    def is_dirty(self):
+        return False
 
 
 @override_settings(
@@ -289,197 +310,200 @@ class CheckForTranslationUpdatesTest(TestCase):
 
     def test_check_for_translation_updates_first_time(self):
         # We don't have a 'translation_last_update' yet to compare to.
-        language_code = "zh-Hans"
-        license = LicenseFactory(version="4.0", license_code="by-nd")
-        legalcode = LegalCodeFactory(
-            license=license, language_code=language_code, translation_last_update=None
-        )
-        resource_slug = license.resource_slug
-
-        mock_repo = MagicMock()
-        mock_repo.is_dirty.return_value = False
-        with mock.patch.object(git, "Repo") as mock_Repo:
-            # 'Repo' is used as a context manager, make it return our mock repo.
-            mock_Repo.return_value.__enter__.return_value = mock_repo
-            with mock.patch.object(
-                TransifexHelper, "get_transifex_resource_stats"
-            ) as mock_get_transifex_resource_stats:
-                mock_get_transifex_resource_stats.return_value = {
-                    resource_slug: {
-                        language_code: {
-                            "translated": {"last_activity": "2007-01-25T12:00:00Z",}
-                        }
-                    }
-                }
-                helper = TransifexHelper()
-                helper.check_for_translation_updates()
-        # We should have set the 'translation_last_update'
-        legalcode.refresh_from_db()
-        self.assertEqual(
-            datetime.datetime(2007, 1, 25, 12, 0, 0, tzinfo=utc),
-            legalcode.translation_last_update,
-        )
+        self.help_test_check_for_translation_updates(first_time=True, changed=None)
 
     def test_check_for_translation_updates_unchanged(self):
         # The translation update timestamp has not changed
-        language_code = "zh-Hans"
-        license = LicenseFactory(version="4.0", license_code="by-nd")
-        legalcode = LegalCodeFactory(
-            license=license,
-            language_code=language_code,
-            translation_last_update=datetime.datetime(
-                2007, 1, 25, 12, 0, 0, tzinfo=utc
-            ),
-        )
-        resource_slug = license.resource_slug
-
-        class DummyRepo:
-            def __init__(self, path):
-                self.index = MagicMock()
-                self.remotes = MagicMock()
-
-            def __str__(self):
-                return "a dummy repo"
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a, **k):
-                pass
-
-            def is_dirty(self):
-                return False
-
-        timestamp = "2007-01-25T12:00:00Z"
-
-        mock_repo = MagicMock()
-        mock_repo.is_dirty.return_value = False
-        with mock.patch.object(git, "Repo", new=DummyRepo):
-            # 'Repo' is used as a context manager, make it return our mock repo.
-            # mock_Repo.return_value.__enter__.return_value = mock_repo
-            with mock.patch.object(
-                TransifexHelper, "get_transifex_resource_stats"
-            ) as mock_get_transifex_resource_stats:
-                mock_get_transifex_resource_stats.return_value = {
-                    resource_slug: {
-                        language_code: {"translated": {"last_activity": timestamp,}}
-                    }
-                }
-                helper = TransifexHelper()
-                with mpo(helper.api_v20, "get") as mock_get:
-                    mock_get.return_value.content = "# empty po file".encode()
-                    with mock.patch(
-                        "licenses.transifex.setup_local_branch"
-                    ) as mock_setup_local_branch:
-                        with mock.patch(
-                            "licenses.transifex.commit_and_push_changes"
-                        ) as mock_commit_and_push_changes:
-                            helper.check_for_translation_updates()
-
-        # Nothing changed, so...nothing should have been done.
-        mock_setup_local_branch.assert_not_called()
-        mock_commit_and_push_changes.assert_not_called()
-        mock_get.assert_not_called()
-        self.assertEqual([], helper.legalcodes_to_update)
-        # We should not have set the 'translation_last_update'
-        legalcode.refresh_from_db()
-        self.assertEqual(
-            datetime.datetime(2007, 1, 25, 12, 0, 0, tzinfo=utc),
-            legalcode.translation_last_update,
-        )
+        self.help_test_check_for_translation_updates(first_time=False, changed=False)
 
     def test_check_for_translation_updates_changed(self):
         # 'translation' is newer than translation_last_update
+        self.help_test_check_for_translation_updates(first_time=False, changed=True)
+
+    def help_test_check_for_translation_updates(self, first_time, changed):
+        """
+        Helper to test several conditions, since all the setup is so convoluted.
+        """
         language_code = "zh-Hans"
         license = LicenseFactory(version="4.0", license_code="by-nd")
+
+        first_translation_update_datetime = datetime.datetime(
+            2007, 1, 25, 12, 0, 0, tzinfo=utc
+        )
+        changed_translation_update_datetime = datetime.datetime(
+            2020, 9, 30, 13, 11, 52, tzinfo=utc
+        )
+
+        if first_time:
+            # We don't yet know when the last update was.
+            legalcode_last_update = None
+        else:
+            # The last update we know of was at this time.
+            legalcode_last_update = first_translation_update_datetime
+
         legalcode = LegalCodeFactory(
             license=license,
             language_code=language_code,
-            translation_last_update=datetime.datetime(
-                2007, 1, 25, 12, 0, 0, tzinfo=utc
-            ),
+            translation_last_update=legalcode_last_update,
         )
         resource_slug = license.resource_slug
 
-        dummy_repo = None
-
-        class DummyRepo:
-            def __init__(self, path):
-                nonlocal dummy_repo
-                dummy_repo = self
-                self.index = MagicMock()
-                self.remotes = MagicMock()
-
-            def __str__(self):
-                return "a dummy repo"
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a, **k):
-                pass
-
-            def is_dirty(self):
-                return False
-
-        timestamp = "2020-09-30T13:11:52Z"
+        # 'timestamp' returns on translation stats from transifex
+        if changed:
+            # now it's the newer time
+            timestamp = changed_translation_update_datetime.isoformat()
+        else:
+            # it's still the first time
+            timestamp = first_translation_update_datetime.isoformat()
 
         mock_repo = MagicMock()
         mock_repo.is_dirty.return_value = False
-        with mock.patch.object(git, "Repo", new=DummyRepo):
-            # 'Repo' is used as a context manager, make it return our mock repo.
-            # mock_Repo.return_value.__enter__.return_value = mock_repo
-            with mock.patch.object(
-                TransifexHelper, "get_transifex_resource_stats"
-            ) as mock_get_transifex_resource_stats:
-                mock_get_transifex_resource_stats.return_value = {
-                    resource_slug: {
-                        language_code: {"translated": {"last_activity": timestamp,}}
-                    }
+
+        legalcodes = [legalcode]
+        dummy_repo = DummyRepo("/trans/repo")
+
+        # A couple of places use git.Repo(path) to get a git repo object. Have them
+        # all get back our same dummy repo.
+        def dummy_repo_factory(path):
+            return dummy_repo
+
+        helper = TransifexHelper()
+
+        with mpo(
+            helper, "handle_legalcodes_with_updated_translations"
+        ) as mock_handle_legalcodes, mpo(
+            helper, "get_transifex_resource_stats"
+        ) as mock_get_transifex_resource_stats:
+            mock_get_transifex_resource_stats.return_value = {
+                resource_slug: {
+                    language_code: {"translated": {"last_activity": timestamp,}}
                 }
-                helper = TransifexHelper()
-                with mpo(helper.api_v20, "get") as mock_get:
-                    mock_get.return_value.content = "# empty po file".encode()
-                    with mock.patch(
-                        "licenses.transifex.setup_local_branch"
-                    ) as mock_setup_local_branch:
-                        with mock.patch(
-                            "licenses.transifex.commit_and_push_changes"
-                        ) as mock_commit_and_push_changes:
-                            with mock.patch.object(
-                                polib.POFile, "save"
-                            ) as mock_pofile_save:
-                                with mock.patch.object(
-                                    polib.POFile, "save_as_mofile"
-                                ) as mock_mofile_save:
-                                    helper.check_for_translation_updates()
-
-        mock_pofile_save.assert_called_with(
-            "/trans/repo/legalcode/zh_Hans/LC_MESSAGES/by-nd_40.po"
-        )
-        mock_mofile_save.assert_called_with(
-            "/trans/repo/legalcode/zh_Hans/LC_MESSAGES/by-nd_40.mo"
-        )
-        mock_setup_local_branch.assert_called_with(
-            dummy_repo, f"cc4-{language_code}".lower(), settings.OFFICIAL_GIT_BRANCH
-        )
-        # commit_and_push_changes(repo, branch_name, commit_msg)
-        mock_commit_and_push_changes.assert_called_with(
-            dummy_repo,
-            f"cc4-{language_code}".lower(),
-            f"Translation changes downloaded {timestamp} from Transifex",
-        )
-        mock_get.assert_called_with(
-            "https://www.transifex.com/api/2//project/CC/resource/by-nd_40/translation/zh-Hans/?mode=translator&file=PO"
-        )
-        self.assertEqual([legalcode], helper.legalcodes_to_update)
-
-        # We should have set the 'translation_last_update'
+            }
+            helper.check_for_translation_updates_with_repo_and_legalcodes(
+                dummy_repo, legalcodes
+            )
+        mock_get_transifex_resource_stats.assert_called_with()
         legalcode.refresh_from_db()
-        self.assertEqual(
-            datetime.datetime(2020, 9, 30, 13, 11, 52, tzinfo=utc),
-            legalcode.translation_last_update,
+        if changed:
+            # we mocked the actual processing, so...
+            self.assertEqual(
+                first_translation_update_datetime, legalcode.translation_last_update
+            )
+            mock_handle_legalcodes.assert_called_with(dummy_repo, [legalcode])
+        else:
+            self.assertEqual(
+                first_translation_update_datetime, legalcode.translation_last_update
+            )
+            mock_handle_legalcodes.assert_called_with(dummy_repo, [])
+        return
+
+    def test_handle_legalcodes_with_updated_translations(self):
+        helper = TransifexHelper()
+        dummy_repo = DummyRepo("/trans/repo")
+
+        # No legalcodes, shouldn't call anything or return anything
+        result = helper.handle_legalcodes_with_updated_translations(dummy_repo, [])
+        self.assertEqual([], result)
+
+        # legalcodes for two branches
+        legalcode1 = LegalCodeFactory(
+            license__version="4.0", license__license_code="by-nc", language_code="fr"
         )
+        legalcode2 = LegalCodeFactory(
+            license__version="4.0", license__license_code="by-nd", language_code="de"
+        )
+        with mpo(helper, "handle_updated_translation_branch") as mock_handle:
+            result = helper.handle_legalcodes_with_updated_translations(
+                dummy_repo, [legalcode1, legalcode2]
+            )
+        self.assertEqual([legalcode1.branch_name(), legalcode2.branch_name()], result)
+        self.assertEqual(
+            [mock.call(dummy_repo, [legalcode1]), mock.call(dummy_repo, [legalcode2]),],
+            mock_handle.call_args_list,
+        )
+
+    def test_handle_updated_translation_branch(self):
+        helper = TransifexHelper()
+        dummy_repo = DummyRepo("/trans/repo")
+        result = helper.handle_updated_translation_branch(dummy_repo, [])
+        self.assertIsNone(result)
+        legalcode1 = LegalCodeFactory(
+            license__version="4.0", license__license_code="by-nc", language_code="fr"
+        )
+        legalcode2 = LegalCodeFactory(
+            license__version="4.0", license__license_code="by-nd", language_code="fr"
+        )
+        with mp("licenses.transifex.setup_local_branch") as mock_setup, mpo(
+            helper, "update_branch_for_legalcode"
+        ) as mock_update_branch, mp(
+            "licenses.transifex.commit_and_push_changes"
+        ) as mock_commit:
+            # setup_local_branch
+            # update_branch_for_legalcode
+            # commit_and_push_changes
+            # branch_object.save()
+            result = helper.handle_updated_translation_branch(
+                dummy_repo, [legalcode1, legalcode2]
+            )
+        self.assertIsNone(result)
+        mock_setup.assert_called_with(
+            dummy_repo, legalcode1.branch_name(), settings.OFFICIAL_GIT_BRANCH
+        )
+        trb = TranslationBranch.objects.get()
+        expected = [
+            mock.call(dummy_repo, legalcode1, trb),
+            mock.call(dummy_repo, legalcode2, trb),
+        ]
+        self.assertEqual(expected, mock_update_branch.call_args_list)
+        mock_commit.assert_called_with(
+            dummy_repo, "Translation changes from Transifex."
+        )
+
+    def test_update_branch_for_legalcode(self):
+        helper = TransifexHelper()
+        dummy_repo = DummyRepo("/trans/repo")
+        legalcode = LegalCodeFactory(
+            license__version="4.0", license__license_code="by-nc", language_code="fr"
+        )
+        helper._stats = {
+            legalcode.license.resource_slug: {
+                legalcode.language_code: {
+                    "translated": {"last_activity": now().isoformat(),}
+                }
+            }
+        }
+        trb = TranslationBranch.objects.create(
+            branch_name=legalcode.branch_name(),
+            version=legalcode.license.version,
+            language_code=legalcode.language_code,
+            complete=False,
+        )
+        content = b"wxyz"
+        # transifex_get_pofile_content
+        # save_content_as_pofile_and_mofile
+        with mpo(helper, "transifex_get_pofile_content") as mock_get_content, mp(
+            "licenses.transifex.save_content_as_pofile_and_mofile"
+        ) as mock_save:
+            mock_get_content.return_value = content
+            mock_save.return_value = [legalcode.translation_filename()]
+            result = helper.update_branch_for_legalcode(dummy_repo, legalcode, trb)
+        self.assertIsNone(result)
+        mock_get_content.assert_called_with(
+            legalcode.license.resource_slug, legalcode.language_code
+        )
+        mock_save.assert_called_with(legalcode.translation_filename(), content)
+        self.assertEqual({legalcode}, set(trb.legalcodes.all()))
+        dummy_repo.index.add.assert_called_with([legalcode.translation_filename()])
+
+    def test_transifex_get_pofile_content(self):
+        helper = TransifexHelper()
+        with mpo(helper, "request20") as mock_req20:
+            mock_req20.return_value = mock.MagicMock(content=b"xxxxxx")
+            result = helper.transifex_get_pofile_content("slug", "lang")
+        mock_req20.assert_called_with(
+            "get", "project/CC/resource/slug/translation/lang/?mode=translator&file=PO"
+        )
+        self.assertEqual(result, b"xxxxxx")
 
 
 class TestTransifexAuthRequests(TestCase):

--- a/licenses/tests/test_utils.py
+++ b/licenses/tests/test_utils.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from django.test import TestCase
 from polib import POEntry
 
+from i18n import DEFAULT_LANGUAGE_CODE
 from licenses.constants import EXCLUDED_LANGUAGE_IDENTIFIERS, EXCLUDED_LICENSE_VERSIONS
 from licenses.models import LegalCode, License
 from licenses.utils import (
@@ -206,17 +207,22 @@ class GetLicenseUtilityTest(TestCase):
 
     def test_get_licenses_code_and_version(self):
         """Should return an iterable of license dictionaries
+        for licenses that have English legalcode,
         with the dictionary keys (license_code, version)
 
         Excluding all versions other than 4.0 licenses
         """
-        licenses = list(License.objects.exclude(version__in=EXCLUDED_LICENSE_VERSIONS))
+        licenses = list(
+            License.objects.filter(
+                legal_codes__language_code=DEFAULT_LANGUAGE_CODE
+            ).exclude(version__in=EXCLUDED_LICENSE_VERSIONS)
+        )
         list_of_licenses_dict = [
             {"license_code": l.license_code, "version": l.version} for l in licenses
         ]
         yielded_licenses = get_licenses_code_and_version()
         yielded_license_list = list(yielded_licenses)
-        self.assertEqual(list_of_licenses_dict, yielded_license_list)
+        self.assertCountEqual(list_of_licenses_dict, yielded_license_list)
 
     def test_get_licenses_code_version_lang(self):
         """Should return an iterable of license dictionaries

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -257,6 +257,8 @@ class TransifexHelper:
         # Commit and push this branch
         commit_and_push_changes(repo, "Translation changes from Transifex.")
 
+        print(f"Updated branch {branch_name} with updated translations and pushed")
+
         # Now that we know the new changes are upstream, save the LegalCode
         # objects with their new translation_last_updates, and the branch object.
         from licenses.models import LegalCode
@@ -338,6 +340,7 @@ class TransifexHelper:
                 or language_code not in self.stats[resource_slug]
             ):
                 logger.error(f"Transifex has no translation for {resource_slug}")
+                print(f"ERROR: Transifex has no translation for {resource_slug}")
                 continue
 
             # We have a translation in this language for this license on Transifex.
@@ -350,6 +353,7 @@ class TransifexHelper:
                 # First time: initialize, don't create branch
                 legalcode.translation_last_update = last_tx_update
                 legalcode.save()
+                print(f"Initialized last update time for {legalcode}")
                 continue
 
             if last_tx_update <= legalcode.translation_last_update:
@@ -357,6 +361,7 @@ class TransifexHelper:
                 continue
 
             # Translation has changed!
+            print(f"Translation has changed for {legalcode}")
             legalcodes_with_updated_translations.append(legalcode)
 
         return self.handle_legalcodes_with_updated_translations(

--- a/licenses/utils.py
+++ b/licenses/utils.py
@@ -1,6 +1,7 @@
 import posixpath
 import re
 import urllib
+from base64 import b64encode
 
 from bs4 import NavigableString
 from polib import POEntry, POFile
@@ -8,7 +9,6 @@ from polib import POEntry, POFile
 from i18n import LANGUAGE_CODE_REGEX
 
 from .constants import EXCLUDED_LICENSE_VERSIONS
-from .models import LegalCode, License
 
 
 def get_code_from_jurisdiction_url(url):
@@ -124,6 +124,8 @@ def get_licenses_code_and_version():
         - license_code
         - version
     """
+    from licenses.models import License
+
     for license in License.objects.exclude(version__in=EXCLUDED_LICENSE_VERSIONS):
         yield {
             "license_code": license.license_code,
@@ -141,6 +143,8 @@ def get_licenses_code_version_language_code():
             language_code
         )
     """
+    from licenses.models import LegalCode
+
     for legalcode in LegalCode.objects.exclude(
         license__version__in=EXCLUDED_LICENSE_VERSIONS
     ):
@@ -289,3 +293,15 @@ def clean_string(s):
     no newlines, no double-spaces.
     """
     return s.strip().replace("\n", " ").replace("  ", " ")
+
+
+def b64encode_string(s: str) -> str:
+    """
+    b64encode the string and return the resulting string.
+    """
+    # This sequence is kind of counter-intuitive, so pull it out into
+    # a util function so we're not worrying about it in the rest of the logic.
+    bits = s.encode()
+    encoded_bits = b64encode(bits)
+    encoded_string = encoded_bits.decode()
+    return encoded_string

--- a/licenses/utils.py
+++ b/licenses/utils.py
@@ -6,7 +6,7 @@ from base64 import b64encode
 from bs4 import NavigableString
 from polib import POEntry, POFile
 
-from i18n import LANGUAGE_CODE_REGEX
+from i18n import DEFAULT_LANGUAGE_CODE, LANGUAGE_CODE_REGEX
 
 from .constants import EXCLUDED_LICENSE_VERSIONS
 
@@ -119,14 +119,18 @@ def parse_legalcode_filename(filename):
 
 
 def get_licenses_code_and_version():
-    """Returns an iterable of license dictionaries
+    """Returns an iterable of license dictionaries that have English Legalcode
+    (not an issue except during tests, really).
     dictionary keys:
         - license_code
         - version
     """
-    from licenses.models import License
+    from licenses.models import LegalCode
 
-    for license in License.objects.exclude(version__in=EXCLUDED_LICENSE_VERSIONS):
+    for legalcode in LegalCode.objects.filter(
+        language_code=DEFAULT_LANGUAGE_CODE
+    ).exclude(license__version__in=EXCLUDED_LICENSE_VERSIONS):
+        license = legalcode.license
         yield {
             "license_code": license.license_code,
             "version": license.version,


### PR DESCRIPTION
## Description
Create git branch when transifex updated, add changed translation files, commit, and push upstream.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
