### PR TITLE
[CC-56] Populate href for related links section.

### DIFF
--- a/cc_licenses/templates/includes/related_links.html
+++ b/cc_licenses/templates/includes/related_links.html
@@ -29,12 +29,12 @@
       {% endif %}
       <ul>
         {% if not show_sampling_deed %}
-          <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="#" class="is-inline body-big" style="font-weight: bold;">{% trans "Learn more about our work" %}</a></li>
+          <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="https://creativecommons.org/about/" class="is-inline body-big" style="font-weight: bold;">{% trans "Learn more about our work" %}</a></li>
         {% endif %}
-        <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="#" class="is-inline body-big" style="font-weight: bold;">{% trans "Learn more about CC Licensing" %}</a></li>
-        <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="#" class="is-inline body-big" style="font-weight: bold;">{% trans "Support our work" %}</a></li>
+        <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="https://creativecommons.org/about/cclicenses/" class="is-inline body-big" style="font-weight: bold;">{% trans "Learn more about CC Licensing" %}</a></li>
+        <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="https://creativecommons.org/donate/" class="is-inline body-big" style="font-weight: bold;">{% trans "Support our work" %}</a></li>
         {% if not show_sampling_deed %}
-          <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="#" class="is-inline body-big" style="font-weight: bold;">{% trans "Use the license for your own material." %}<i class="icon external-link padding-bottom-small caption"></i></a></li>
+          <li><span class="body-bigger padding-{% end %}-normal padding-top-small">&#8226;</span><a href="https://chooser-beta.creativecommons.org/" class="is-inline body-big" style="font-weight: bold;">{% trans "Use the license for your own material." %}<i class="icon external-link padding-bottom-small caption"></i></a></li>
         {% endif %}
       </ul>
     </li>


### PR DESCRIPTION
https://caktus.atlassian.net/browse/CC-56

This ticket is still in blocked. We are waiting on the tooltip component from the vocabulary team. This PR populates the href attributed for the related links section elements.
