### PR TITLE
[CC-52] Fix linking licenses dropdown to right page

### DIFF
--- a/licenses/views.py
+++ b/licenses/views.py
@@ -1,5 +1,6 @@
 import re
 from operator import itemgetter
+from typing import Iterable
 
 from django.shortcuts import get_object_or_404, render
 from django.utils.translation import get_language_info
@@ -55,7 +56,12 @@ def home(request):
     return render(request, "home.html", context)
 
 
-def get_languages_and_links_for_legalcodes(legalcodes, selected_language_code):
+def get_languages_and_links_for_legalcodes(
+    legalcodes: Iterable[LegalCode], selected_language_code: str, license_or_deed: str
+):
+    """
+    license_or_deed should be "license" or "deed", controlling which kind of page we link to.
+    """
     languages_and_links = [
         {
             "language_code": legal_code.language_code,
@@ -64,7 +70,9 @@ def get_languages_and_links_for_legalcodes(legalcodes, selected_language_code):
             "name_for_sorting": get_language_info(legal_code.language_code)[
                 "name_local"
             ].lower(),
-            "link": legal_code.license_url(),
+            "link": legal_code.license_url()
+            if license_or_deed == "license"
+            else legal_code.deed_url(),
             "selected": selected_language_code == legal_code.language_code,
         }
         for legal_code in legalcodes
@@ -87,7 +95,7 @@ def view_license(request, license_code, version, jurisdiction=None, language_cod
     )
 
     languages_and_links = get_languages_and_links_for_legalcodes(
-        legalcode.license.legal_codes.all(), language_code
+        legalcode.license.legal_codes.all(), language_code, "license"
     )
 
     translation = legalcode.get_translation_object()
@@ -116,7 +124,7 @@ def view_deed(request, license_code, version, jurisdiction=None, language_code=N
         language_code=language_code,
     )
     languages_and_links = get_languages_and_links_for_legalcodes(
-        legalcode.license.legal_codes.all(), language_code
+        legalcode.license.legal_codes.all(), language_code, "deed"
     )
 
     translation = legalcode.get_translation_object()


### PR DESCRIPTION
## Fixes
Fixes languages dropdown on deed pages going to license pages instead of the corresponding deed page.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
