### PR TITLE
[CC-31] Running compilemessages from load_html_files fails, just save mofiles ourselves.

### DIFF
--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -110,13 +110,18 @@ def active_translation(translation: DjangoTranslation):
         _active.value = previous_translation
 
 
+def save_pofile_as_pofile_and_mofile(pofile: polib.POFile, pofile_path: str):
+    """Returns pofile_abspath, mofile_abspath"""
+    pofile.save(pofile_path)
+    mofilepath = re.sub(r"\.po$", ".mo", pofile_path)
+    pofile.save_as_mofile(mofilepath)
+    return (pofile_path, mofilepath)
+
+
 def save_content_as_pofile_and_mofile(path: str, content: bytes):
     """Returns pofile_abspath, mofile_abspath"""
     pofile = polib.pofile(pofile=content.decode(), encoding="utf-8")
-    pofile.save(path)
-    mofilepath = re.sub(r"\.po$", ".mo", path)
-    pofile.save_as_mofile(mofilepath)
-    return (path, mofilepath)
+    return save_pofile_as_pofile_and_mofile(pofile, path)
 
 
 def get_pofile_content(pofile: polib.POFile) -> str:

--- a/licenses/management/commands/upload_license_messages.py
+++ b/licenses/management/commands/upload_license_messages.py
@@ -5,5 +5,7 @@ from licenses.models import License
 
 class Command(BaseCommand):
     def handle(self, **options):
-        license = License.objects.get(version="4.0", license_code="by-nc-nd")
-        license.tx_upload_messages()
+        for license in License.objects.filter(
+            version="4.0", license_code__startswith="by"
+        ):
+            license.tx_upload_messages()

--- a/licenses/models.py
+++ b/licenses/models.py
@@ -125,7 +125,7 @@ class LegalCode(models.Model):
     def get_pofile(self) -> polib.POFile:
         with open(self.translation_filename(), "rb") as f:
             content = f.read()
-        return polib.pofile(content)
+        return polib.pofile(content.decode(), encoding="utf-8")
 
     def get_english_pofile(self) -> polib.POFile:
         if self.language_code != DEFAULT_LANGUAGE_CODE:

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -110,7 +110,7 @@ class LegalCodeModelTest(TestCase):
             with mock.patch.object(polib, "pofile") as mock_pofile:
                 mock_pofile.return_value = test_pofile
                 result = legalcode.get_pofile()
-        mock_pofile.assert_called_with(b"")
+        mock_pofile.assert_called_with("", encoding="utf-8")
         self.assertEqual(test_pofile, result)
 
     @override_settings(TRANSLATION_REPOSITORY_DIRECTORY="/some/dir")

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -493,7 +494,10 @@ class CheckForTranslationUpdatesTest(TestCase):
         )
         mock_save.assert_called_with(legalcode.translation_filename(), content)
         self.assertEqual({legalcode}, set(trb.legalcodes.all()))
-        dummy_repo.index.add.assert_called_with([legalcode.translation_filename()])
+        relpath = os.path.relpath(
+            legalcode.translation_filename(), settings.TRANSLATION_REPOSITORY_DIRECTORY
+        )
+        dummy_repo.index.add.assert_called_with([relpath])
 
     def test_transifex_get_pofile_content(self):
         helper = TransifexHelper()

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -343,9 +343,7 @@ class TransifexHelper:
                 resource_slug not in resource_slugs_on_transifex
                 or language_code not in self.stats[resource_slug]
             ):
-                logger.error(f"Transifex has no translation for {resource_slug}")
-                print(f"ERROR: Transifex has no translation for {resource_slug}")
-                continue
+                raise Exception(f"Transifex has no translation for {resource_slug}")
 
             # We have a translation in this language for this license on Transifex.
             # When was it last updated?

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -230,7 +230,11 @@ class TransifexHelper:
             resource_slug, legalcode.language_code
         )
         filenames = save_content_as_pofile_and_mofile(pofile_path, pofile_content)
-        repo.index.add(filenames)
+        relpaths = [
+            os.path.relpath(filename, settings.TRANSLATION_REPOSITORY_DIRECTORY)
+            for filename in filenames
+        ]
+        repo.index.add(relpaths)
 
     def handle_updated_translation_branch(self, repo, legalcodes):
         # legalcodes whose translations have been updated and all belong to the same translation branch


### PR DESCRIPTION
## Description
Running compilemessages from load_html_files fails, just save mofile ourselves.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
