### PR TITLE
[CC-55] "view legal code as plain text" link when clicked downloads a plaint text…

### DIFF
--- a/cc_licenses/templates/includes/legalcode_40_license.html
+++ b/cc_licenses/templates/includes/legalcode_40_license.html
@@ -1,7 +1,7 @@
 {% load bidi i18n license_tags %}
 <div id="legal-code-body" class="padding-larger margin-top-bigger has-text-black">
   {% include 'includes/snippet/icon_header_snippet.html' %}
-  <div>
+  <div id="plain-text-body">
     <h3 class="padding-bottom-normal b-header">
       {% if legalcode|is_one_of:"by" %}{# Long full title #}
         {% blocktrans trimmed %}Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License{% endblocktrans %}

--- a/cc_licenses/templates/includes/view_legal_code_link_plain_text.html
+++ b/cc_licenses/templates/includes/view_legal_code_link_plain_text.html
@@ -1,5 +1,23 @@
 {% load i18n %}
 
 <div id="legal-code-plain-text" style="font-weight: bold;" class="padding-vertical-normal" >
-  <p class="body-big"><a href="#" class="link">{% trans "View Legal Code as plain text" %}</a></p>
+  <p class="body-big">
+    <a id="download-plain-text" href="#" class="link" download="{% include 'includes/snippet/license_medium_title.html'%}.txt">
+      {% trans "View Legal Code as plain text" %}
+    </a>
+  </p>
 </div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const downloadLink = document.querySelector("a#download-plain-text")
+    const legalCodeBody = document.querySelector("div#plain-text-body")
+    const legalCodeBodyText = legalCodeBody.textContent
+    const file = new Blob([legalCodeBodyText], {
+      type: "text/plain;charset=utf-8"
+    })
+    fileUrl = window.URL.createObjectURL(file);
+    downloadLink.href = fileUrl
+    // this.setAttribute('download', filename);
+  })
+</script>

--- a/cc_licenses/templates/includes/view_legal_code_link_plain_text.html
+++ b/cc_licenses/templates/includes/view_legal_code_link_plain_text.html
@@ -18,6 +18,5 @@
     })
     fileUrl = window.URL.createObjectURL(file);
     downloadLink.href = fileUrl
-    // this.setAttribute('download', filename);
   })
 </script>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #8 by @santisoler 

## Description
<!-- Concisely describe what the pull request does. -->
On the legal code page for a license. The `View legal code as plain text` button when clicked downloads a plain text file containing the license's legal code. 

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
This a PR vanilla javascript implementation.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->
1) Navigate to `localhost:8000`. The table on the homepage features various licenses. (for testing purposes)
2) Click on any `License`.
3) Navigate to `View legal code as plain text` beneath the legal code section.
4) Click `View legal code as plain text`
5) The file should be downloaded. The text of the license's legal code should be in the language that the page is being viewed.

Since this is vanilla javascript implementation, this solution should be tested across browsers to ensure browser support.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
