### PR TITLE
[CC-60] When translation branch has been updated, update its static files in git

### DIFF
--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -437,6 +437,8 @@ class CheckForTranslationUpdatesTest(TestCase):
         with mp("licenses.transifex.setup_local_branch") as mock_setup, mpo(
             helper, "update_branch_for_legalcode"
         ) as mock_update_branch, mp(
+            "licenses.transifex.call_command"
+        ) as mock_call_command, mp(
             "licenses.transifex.commit_and_push_changes"
         ) as mock_commit:
             # setup_local_branch
@@ -450,6 +452,11 @@ class CheckForTranslationUpdatesTest(TestCase):
         mock_setup.assert_called_with(
             dummy_repo, legalcode1.branch_name(), settings.OFFICIAL_GIT_BRANCH
         )
+        # Should have published static files for this branch
+        expected = [
+            mock.call("publish", branch_name=legalcode1.branch_name()),
+        ]
+        self.assertEqual(expected, mock_call_command.call_args_list)
         trb = TranslationBranch.objects.get()
         expected = [
             mock.call(dummy_repo, legalcode1, trb),

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -12,6 +12,7 @@ import polib
 import requests
 import requests.auth
 from django.conf import settings
+from django.core.management import call_command
 
 from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import get_pofile_content, save_content_as_pofile_and_mofile
@@ -247,6 +248,7 @@ class TransifexHelper:
 
     def handle_updated_translation_branch(self, repo, legalcodes):
         # legalcodes whose translations have been updated and all belong to the same translation branch
+        # if we update the branch, we'll also publish updates to its static files.
         if not legalcodes:
             return
         branch_name = legalcodes[0].branch_name()
@@ -268,6 +270,16 @@ class TransifexHelper:
         )
         for legalcode in legalcodes:
             self.update_branch_for_legalcode(repo, legalcode, branch_object)
+
+        self.say(2, "Publishing static files")
+        call_command("publish", branch_name=branch_name)
+        repo.index.add(
+            [
+                os.path.relpath(
+                    settings.DISTILL_DIR, settings.TRANSLATION_REPOSITORY_DIRECTORY
+                )
+            ]
+        )
 
         # Commit and push this branch
         self.say(2, "Committing and pushing")


### PR DESCRIPTION
## Description
When a translation has been updated in Transifex and the update checking task has had time to run, the corresponding translation branch in GitHub should have, in its build directory, updated html files corresponding to the updated translation

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
