### PR TITLE
[CCK-22] Display license-appropriate content in deeds

### DIFF
--- a/cc_licenses/templates/includes/deed_body.html
+++ b/cc_licenses/templates/includes/deed_body.html
@@ -1,13 +1,26 @@
-{% load i18n %}
+{% load i18n license_tags static %}
 <div id="deed-body" class="margin-vertical-bigger padding-xxl" >
   {% include 'includes/snippet/icon_header_snippet.html' %}
   {# Deed Main Content (below) seems to be coming straight from database based on the example provided from cc5 #}
   {# Adding an example of what the deed should look like here #}
   <h3 class="b-header has-text-black padding-bottom-big padding-top-normal" style="font-weight: bold;">{% trans "You are free to:" %}</h3>
-  <p class="has-text-black body-big padding-bottom-normal">{% blocktrans %}<strong>Share</strong>  &mdash; copy and redistribute the material in any medium or format{% endblocktrans %}
-  </p>
-  <p class="has-text-black body-big padding-bottom-small">{% blocktrans %}<strong>Adapt</strong>  &mdash; remix, transform, and build upon the material{% endblocktrans %}
-  </p>
+
+  {% if license.prohibits_commercial_use or legalcode|is_one_of:"by,by-sa" %}
+   <p class="has-text-black body-big padding-bottom-normal">{% blocktrans %}<strong>Share</strong>  &mdash; copy and redistribute the material in any medium or format{% endblocktrans %}</p>
+  {% else %}
+    <p class="has-text-black body-big padding-bottom-normal">{% blocktrans %}<strong>Share</strong> — copy and redistribute the material in any medium or format for any purpose, even commercially.{% endblocktrans %}</p>
+  {% endif %}
+
+  {% if license.permits_derivative_works %}
+    {% if license.prohibits_commercial_use %}
+      <p class="has-text-black body-big padding-bottom-small">{% blocktrans %}<strong>Adapt</strong>  &mdash; remix, transform, and build upon the material{% endblocktrans %}
+      </p>
+    {% else %}
+      <p class="has-text-black body-big padding-bottom-small">{% blocktrans %}<strong>Adapt</strong>  &mdash; remix, transform, and build upon the material for any purpose, even commercially.{% endblocktrans %}
+      </p>
+    {% endif %}
+  {% endif %}
+
   <p class="has-text-black body-big padding-bottom-small">
     {% blocktrans %}The licensor cannot revoke these freedoms as long as you follow the license terms.{% endblocktrans %}
   </p>
@@ -22,21 +35,24 @@
     <div class="column is-11">
       <p class="has-text-black body-big padding-bottom-normal">
         <span style="font-weight: bold;">{% trans "Attribution" %}</span> -
-
         {% blocktrans %}You must give <a href="#" id="appropriate_credit_popup" class="helpLink">appropriate credit</a></span>, provide a link to the license, and <span rel="cc:requires" resource="http://creativecommons.org/ns#Notice"><a href="#" id="indicate_changes_popup" class="helpLink">indicate if changes were made</a></span>.  You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.{% endblocktrans %}
       </p>
     </div>
     {# endfor #}
+
+  {% if license.prohibits_commercial_use %}
     <div class="column is-1">
       {% include 'includes/snippet/icon.html' with icon_type='cc-nc' %}
     </div>
     <div class="column is-11">
       <p class="has-text-black body-big padding-bottom-normal">
         <span style="font-weight: bold;">{% trans "NonCommercial" %}</span> -
-
         {% blocktrans %}You may not use the material for <a href="#" id="commercial_purposes_popup" class="helpLink">commercial purposes</a>.{% endblocktrans %}
       </p>
     </div>
+  {% endif %}
+
+  {% if license.requires_share_alike %}
     <div class="column is-1">
       {% include 'includes/snippet/icon.html' with icon_type='cc-sa' %}
     </div>
@@ -45,6 +61,19 @@
         <span style="font-weight: bold;">{% trans "ShareAlike" %}</span> - {% blocktrans %}If you remix, transform, or build upon the material, you must distribute your contributions under the <a href="#" id="same_license_popup" class="helpLink">same license</a> as the original.{% endblocktrans %}
       </p>
     </div>
+  {% endif %}
+
+{% if not license.permits_derivative_works %}
+    <div class="column is-1">
+      {% include 'includes/snippet/icon.html' with icon_type='cc-nd' %}
+    </div>
+    <div class="column is-11">
+      <p class="has-text-black body-big padding-bottom-normal">
+        <span style="font-weight: bold;">{% trans "NoDerivatives" %}</span> - {% blocktrans %}If you <a href="#" id="some_kinds_of_mods_popup" class="helpLink">remix, transform, or build upon</a> the material, you may not distribute the modified material.{% endblocktrans %}
+      </p>
+    </div>
+{% endif %}
+
     <div class="column is-1">
     </div>
     <div class="column is-11">

--- a/cc_licenses/templates/includes/snippet/icon.html
+++ b/cc_licenses/templates/includes/snippet/icon.html
@@ -5,7 +5,7 @@
 
 {% if is_icon_header %}
 <i
-  class="{{ icon_type }} icon has-text-black has-background-white is-size-1 padding-{% start %}-big is-hidden-touch margin-normal {{ additional_classes }}"
+  class="{{ icon_type }} icon has-text-black has-background-white is-size-1 is-hidden-touch margin-normal {{ additional_classes }}"
 ></i>
 <i
   class="{{ icon_type }} icon has-text-black has-background-white is-size-2 padding-{% start %}-normal is-hidden-desktop margin-small {{ additional_classes }}"

--- a/cc_licenses/templates/includes/snippet/icon_header_snippet.html
+++ b/cc_licenses/templates/includes/snippet/icon_header_snippet.html
@@ -1,35 +1,65 @@
 {% load bidi %}
 
-<h3 class="is-vcentered is-hidden-touch">
+{# https://bulma.io/documentation/helpers/visibility-helpers/ #}
+{# is-hidden-touch means hidden if screen is *narrower* than the typical desktop #}
+{# So this is the DESKTOP or WIDE version of the icon row. #}
+{# Figma mockup has this line left-justified #}
+<h3 class="is-hidden-touch">
   {# Icon Sections #}
     <span class="padding-{% end %}-bigger">
     {# For loop through icons classes that are being sent from model #}
       {% include 'includes/snippet/icon.html' with icon_type='cc-logo' additional_classes='padding-bottom-small' is_icon_header=True %}
       {% include 'includes/snippet/icon.html' with icon_type='cc-by' additional_classes='padding-bottom-small' is_icon_header=True %}
-      {% include 'includes/snippet/icon.html' with icon_type='cc-nc' additional_classes='padding-bottom-small' is_icon_header=True %}
-      {% include 'includes/snippet/icon.html' with icon_type='cc-sa' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% if license.prohibits_commercial_use %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-nc' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% endif %}
+      {% if license.requires_share_alike %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-sa' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% endif %}
+      {% if not license.permits_derivative_works %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-nd' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% endif %}
     </span>
   {{ legalcode.fat_code }}
 </h3>
-<h3 class="is-vcentered is-hidden-desktop is-hidden-mobile has-text-centered">
+{# is-hidden-desktop means hidden if screen is larger than typical mobile and tablet-sized screens #}
+{# is-hidden-mobile means hidden if screen is no wider than a typical mobile device #}
+{# I think that leaves this as the TABLET or MEDIUM version. #}
+<h3 class="is-hidden-desktop is-hidden-mobile">
   {# Icon Sections #}
     <span class="padding-{% end %}-big">
     {# For loop through icons classes that are being sent from model #}
       {% include 'includes/snippet/icon.html' with icon_type='cc-logo' additional_classes='padding-bottom-small' is_icon_header=True %}
       {% include 'includes/snippet/icon.html' with icon_type='cc-by' additional_classes='padding-bottom-small' is_icon_header=True %}
-      {% include 'includes/snippet/icon.html' with icon_type='cc-nc' additional_classes='padding-bottom-small' is_icon_header=True %}
-      {% include 'includes/snippet/icon.html' with icon_type='cc-sa' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% if license.prohibits_commercial_use %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-nc' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% endif %}
+      {% if license.requires_share_alike %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-sa' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% endif %}
+      {% if not license.permits_derivative_works %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-nd' additional_classes='padding-bottom-small' is_icon_header=True %}
+      {% endif %}
     </span>
     {{ legalcode.fat_code }}
 </h3>
-<h3 class="is-hidden-tablet has-text-centered">
+{# is-hidden-tablet means hidden for any screen bigger than a typical mobile (go figure) #}
+{# so this is the PHONE or NARROW version. #}
+<h3 class="is-hidden-tablet">
   {# Icon Sections #}
     <span>
     {# For loop through icons classes that are being sent from model #}
       {% include 'includes/snippet/icon.html' with icon_type='cc-logo' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
       {% include 'includes/snippet/icon.html' with icon_type='cc-by' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
-      {% include 'includes/snippet/icon.html' with icon_type='cc-nc' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
-      {% include 'includes/snippet/icon.html' with icon_type='cc-sa' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
+      {% if license.prohibits_commercial_use %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-nc' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
+      {% endif %}
+      {% if license.requires_share_alike %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-sa' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
+      {% if not license.permits_derivative_works %}
+        {% include 'includes/snippet/icon.html' with icon_type='cc-nd' additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_icon_header=True %}
+      {% endif %}
+      {% endif %}
     </span>
 </h3>
 <h4 class="has-text-centered is-hidden-tablet padding-{% start %}-normal">{{ legalcode.fat_code }}</h4>

--- a/licenses/templates/deed_40.html
+++ b/licenses/templates/deed_40.html
@@ -2,7 +2,7 @@
 {% load i18n static %}
 
 {% block about %}{{ license.about }}{% endblock %}
-{% block title %}Creative Commons &mdash; {{ title }} {% endblock %}
+{% block title %}Creative Commons &mdash; {% include "includes/snippet/license_medium_title.html" %} {% endblock %}
 
 {% block active-breadcrumb-li %}
 <li class="is-active"><a href="{{ legalcode.deed_url }}" aria-current="page displayed">{% trans "License Deed for" %} {{ legalcode.fat_code }}</a></li>

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -138,6 +138,7 @@ def view_deed(request, license_code, version, jurisdiction=None, language_code=N
             request,
             "deed_40.html",
             {
+                "additional_classes": "",
                 "fat_code": legalcode.license.fat_code(),
                 "languages_and_links": languages_and_links,
                 "legalcode": legalcode,


### PR DESCRIPTION
## Fixes
In 4.0 deeds, display the appropriate icons, rights, and restrictions
depending on which license we're displaying the deed for.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
