### PR TITLE
Update text in sidebar for CC0 to match English messages for translation

### DIFF
--- a/cc_licenses/templates/includes/menu-sidebar.html
+++ b/cc_licenses/templates/includes/menu-sidebar.html
@@ -17,19 +17,19 @@
           </li>
           <li class="columns">
             <div class="body-bigger is-inline-block column is-1 py-0 my-0">&#8226;</div>
-            <a class="is-block column" href="#copyright">{% blocktrans trimmed %}Copyright and Related Rights{% endblocktrans %}</a>
+            <a class="is-block column" href="#copyright">{% blocktrans trimmed %}1. Copyright and Related Rights.{% endblocktrans %}</a>
           </li>
           <li class="columns">
             <div class="body-bigger is-inline-block column is-1 py-0 my-0">&#8226;</div>
-            <a class="is-block column" href="#waiver">{% blocktrans trimmed %}Waiver{% endblocktrans %}</a>
+            <a class="is-block column" href="#waiver">{% blocktrans trimmed %}2. Waiver.{% endblocktrans %}</a>
           </li>
           <li class="columns">
             <div class="body-bigger is-inline-block column is-1 py-0 my-0">&#8226;</div>
-            <a class="is-block column" href="#fallback">{% blocktrans trimmed %}Public License Fallback{% endblocktrans %}</a>
+            <a class="is-block column" href="#fallback">{% blocktrans trimmed %}3. Public License Fallback.{% endblocktrans %}</a>
           </li>
           <li class="columns">
             <div class="body-bigger is-inline-block column is-1 py-0 my-0">&#8226;</div>
-            <a class="is-block column" href="#limitations">{% blocktrans trimmed %}Limitations and Disclaimers{% endblocktrans %}</a>
+            <a class="is-block column" href="#limitations">{% blocktrans trimmed %}4. Limitations and Disclaimers.{% endblocktrans %}</a>
           </li>
 
         {% elif license.version == "3.0" and license.jurisdiction_code != "" %}


### PR DESCRIPTION
## Description
Update text in sidebar for CC0 to match English messages for translation. They were missing a leading number and a trailing period and so weren't finding their translations.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
