### PR TITLE
Fix logos for non-4.0, non-CC0 licenses

### DIFF
--- a/licenses/models.py
+++ b/licenses/models.py
@@ -436,8 +436,8 @@ class License(models.Model):
         result = ["cc-logo"]  # Everybody gets this
         if self.license_code == "CC0":
             result.append("cc-zero")
-        elif self.version == "4.0":
-            result.append("cc-by")  # All the 4.0 licenses are BY
+        elif self.license_code.startswith("by"):
+            result.append("cc-by")
             if self.prohibits_commercial_use:
                 result.append("cc-nc")
             if self.requires_share_alike:

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -416,6 +416,7 @@ class LicenseModelTest(TestCase):
         self.assertEqual(
             ["cc-logo", "cc-by"],
             LicenseFactory(
+                license_code="by",
                 version="4.0",
                 prohibits_commercial_use=False,
                 requires_share_alike=False,
@@ -425,7 +426,8 @@ class LicenseModelTest(TestCase):
         self.assertEqual(
             ["cc-logo", "cc-by", "cc-nc"],
             LicenseFactory(
-                version="4.0",
+                license_code="by-nc",
+                version="3.0",
                 prohibits_commercial_use=True,
                 requires_share_alike=False,
                 permits_derivative_works=True,
@@ -434,6 +436,7 @@ class LicenseModelTest(TestCase):
         self.assertEqual(
             ["cc-logo", "cc-by", "cc-nd"],
             LicenseFactory(
+                license_code="by-nd",
                 version="4.0",
                 prohibits_commercial_use=False,
                 requires_share_alike=False,
@@ -443,6 +446,7 @@ class LicenseModelTest(TestCase):
         self.assertEqual(
             ["cc-logo", "cc-by", "cc-sa"],
             LicenseFactory(
+                license_code="by-sa",
                 version="4.0",
                 prohibits_commercial_use=False,
                 requires_share_alike=True,
@@ -452,7 +456,18 @@ class LicenseModelTest(TestCase):
         self.assertEqual(
             ["cc-logo", "cc-by", "cc-nc", "cc-sa"],
             LicenseFactory(
+                license_code="by-nc-sa",
                 version="4.0",
+                prohibits_commercial_use=True,
+                requires_share_alike=True,
+                permits_derivative_works=True,
+            ).logos(),
+        )
+        self.assertEqual(
+            ["cc-logo", "cc-by", "cc-nc", "cc-sa"],
+            LicenseFactory(
+                license_code="by-nc-sa",
+                version="3.0",
                 prohibits_commercial_use=True,
                 requires_share_alike=True,
                 permits_derivative_works=True,


### PR DESCRIPTION
## Fixes
3.0 license pages weren't displaying the icons to indicate the license properties,
like "non-commercial".

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
