### PR TITLE
Pin vocabulary version to v2020.11.1.

### DIFF
--- a/cc_licenses/templates/base.html
+++ b/cc_licenses/templates/base.html
@@ -13,7 +13,10 @@
     <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
     <meta name="keywords" content="{% block meta-keywords %}{% endblock %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary/css/vocabulary.css">
+    {# We're pinning vocabulary v2020.11.1 because v2020.11.2 had a change that broke headers for this site. #}
+    {# So far, I've been unable to find any documentation about it other than the warning in the release #}
+    {# notes that there was a breaking change. #}
+    <link rel="stylesheet" href="https://unpkg.com/@creativecommons/vocabulary@v2020.11.1/css/vocabulary.css">
 </head>
 <body typeoff="cc:License">
   {% include 'includes/header.html' %}
@@ -38,7 +41,7 @@
   </main>
   {% include 'includes/footer.html' %}
 
-  <script src="https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary/js/vocabulary.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary@v2020.11.1/js/vocabulary.js"></script>
 
   <script>
       /**
@@ -51,7 +54,7 @@
       const getFullyQualifiedUrl = (version, path) => {
       //   let baseUrl = 'https://unpkg.com/@creativecommons/vocabulary'
         // If you prefer jsDelivr instead, use
-        let baseUrl = 'https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary'
+        let baseUrl = 'https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary@v2020.11.1'
         return `${baseUrl}@${version}/${path}`
       }
 


### PR DESCRIPTION
 V2020.11.2 changed something that made our header links white on white and unreadable.

## Fixes
Header links were white on white and invisible.

## Description
Pin vocabulary version to v2020.11.1.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
