### PR TITLE
Some plaintext legalcode (for ported licenses) not working

### DIFF
--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -279,12 +279,15 @@ class ViewLicenseTest(TestCase):
             )
             self.assertEqual(200, rsp.status_code)
             self.assertGreater(len(rsp.content.decode()), 0)
-        lc = LegalCodeFactory(license__version="3.0", language_code="fr", license__license_code="by", license__jurisdiction_code="ch")
+        lc = LegalCodeFactory(
+            license__version="3.0",
+            language_code="fr",
+            license__license_code="by",
+            license__jurisdiction_code="ch",
+        )
         url = lc.plain_text_url
         rsp = self.client.get(url)
-        self.assertEqual(
-            'text/plain; charset="utf-8"', rsp._headers["content-type"][1]
-        )
+        self.assertEqual('text/plain; charset="utf-8"', rsp._headers["content-type"][1])
         self.assertEqual(200, rsp.status_code)
         self.assertGreater(len(rsp.content.decode()), 0)
 

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -279,6 +279,14 @@ class ViewLicenseTest(TestCase):
             )
             self.assertEqual(200, rsp.status_code)
             self.assertGreater(len(rsp.content.decode()), 0)
+        lc = LegalCodeFactory(license__version="3.0", language_code="fr", license__license_code="by", license__jurisdiction_code="ch")
+        url = lc.plain_text_url
+        rsp = self.client.get(url)
+        self.assertEqual(
+            'text/plain; charset="utf-8"', rsp._headers["content-type"][1]
+        )
+        self.assertEqual(200, rsp.status_code)
+        self.assertGreater(len(rsp.content.decode()), 0)
 
 
 class LicenseDeedViewTest(LicensesTestsMixin, TestCase):

--- a/licenses/urls.py
+++ b/licenses/urls.py
@@ -175,6 +175,14 @@ urlpatterns = [
         view_license,
         name="licenses_default_language_with_jurisdiction",
     ),
+    path(
+        # Jurisdiction and language set
+        # e.g. /licenses/by-nc-sa/3.0/de/legalcode
+        "<code:license_code>/<version:version>/<jurisdiction:jurisdiction>/legalcode.<lang:language_code>.txt",
+        view_license,
+        name="licenses_default_language_with_jurisdiction",
+        kwargs=dict(is_plain_text=True),
+    ),
     #
     # DEED PAGES
     #

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -146,6 +146,7 @@ def view_license(
             html = render_to_string(**kwargs)
             soup = BeautifulSoup(html, "lxml")
             plain_text_soup = soup.find(id="plain-text-marker")
+            # FIXME: prune the "img" tags from this before saving again.
             with tempfile.NamedTemporaryFile(mode="w+b") as temp:
                 temp.write(plain_text_soup.encode("utf-8"))
                 output = subprocess.run(

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,4 +51,3 @@ text-unidecode==1.3       # via python-slugify
 toml==0.10.1              # via pre-commit
 urllib3==1.25.9           # via requests, transifex-client
 virtualenv==20.0.25       # via pre-commit
-https://github.com/creativecommons/cc-link-checker/archive/v2020.09.1.zip  # https://github.com/creativecommons/cc-link-checker


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #72  by @aldenstpage 

## Description
Adds a URL for serving plain text licenses for ported translated licenses, like the French 3.0 BY switzerland license.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
