### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # https://help.github.com/en/articles/about-code-owners
 * @creativecommons/sre
 * @creativecommons/contractor-caktus-group
+* @creativecommons/ct-cc-licenses-maintainers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.