### PR TITLE
Update code, settings, and docs for main default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,19 +379,19 @@ This is most easily done from a developer environment.
 Check out the [creativecommons/cc-licenses-data][repodata] repository next to
 your `cc-licenses` working tree.
 
-Decide what branch you want to generate the site from, e.g. "develop".
+Decide what branch you want to generate the site from, e.g. "main".
 
 In the cc-licenses-data working directory, check out that branch and make sure
 it's up-to-date, e.g.:
 ```shell
-git checkout develop
-git pull origin develop
+git checkout main
+git pull origin main
 ```
 
 Then change back to the cc-licenses tree, and run the publish management
-command, probably starting with "\--nopush":
+command, probably starting with "--nopush":
 ```shell
-pipenv run ./manage.py publish --nopush --branch=develop
+pipenv run ./manage.py publish --nopush --branch=main
 ```
 
 This will write the HTML files in the cc-licenses-data tree under `build` and

--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -285,7 +285,7 @@ TRANSIFEX = {
 
 # The git branch where the official, approved, used in production translations
 # are.
-OFFICIAL_GIT_BRANCH = "develop"
+OFFICIAL_GIT_BRANCH = "main"
 
 # Path to private keyfile to use when pushing up to data repo
 TRANSLATION_REPOSITORY_DEPLOY_KEY = os.getenv(

--- a/docs/dev/provisioning.rst
+++ b/docs/dev/provisioning.rst
@@ -36,14 +36,13 @@ Change to the new directory for the rest of these steps::
 
     $ cd cc-licenses
 
-Check out the "develop" branch if you're wanting to test things still
-in development, or "master" for production::
+Check out the "main" branch::
 
-    $ git checkout develop
+    $ git checkout main
 
 Do a ``git pull`` to make sure you have the latest from upstream::
 
-    $ git pull origin develop
+    $ git pull origin main
 
 A word to the wise: I often forget that these things change, and have
 to remind myself to use the documentation from the version of the code
@@ -63,7 +62,7 @@ Activate the venv::
     $ . /somepath/cc-licenses-venv/bin/activate
 
 Install the Python requirements for production into the virtual
-environment. (This is the same whether deploying develop or master.)::
+environment::
 
     $ pip install -r requirements/production.txt
 

--- a/docs/dev/translation.rst
+++ b/docs/dev/translation.rst
@@ -57,9 +57,9 @@ Updating messages on Transifex
 Anytime there have been changes to the messages in the code or templates,
 a developer should update the messages on Transifex as follows:
 
-1. Make sure you have the latest code from develop::
+1. Make sure you have the latest code from main::
 
-     git checkout develop
+     git checkout main
      git pull
 
 #. regenerate the English (only) .po files::
@@ -68,7 +68,7 @@ a developer should update the messages on Transifex as follows:
 
 #. Run ``git diff`` and make sure the changes look reasonable.
 
-#. If so, commit the updated .po file to develop and push it upstream::
+#. If so, commit the updated .po file to main and push it upstream::
 
      git commit -m "Updated messages" locale/en/LC_MESSAGES/*.po
      git push
@@ -84,11 +84,11 @@ Updating translations from Transifex
 ------------------------------------
 
 Anytime translations on Transifex have been updated, someone should update our
-translation files on the develop branch as follows:
+translation files on the main branch as follows:
 
-1. Make sure you have the latest code from develop::
+1. Make sure you have the latest code from main::
 
-     git checkout develop
+     git checkout main
      git pull
 
 #. `Pull <http://support.transifex.com/customer/portal/articles/996157-getting-translations>`_

--- a/licenses/management/commands/check_for_translation_updates.py
+++ b/licenses/management/commands/check_for_translation_updates.py
@@ -4,7 +4,7 @@ from django.core.management import BaseCommand, call_command
 # First-party/Local
 from licenses.transifex import TransifexHelper
 
-TOP_BRANCH = "develop"
+TOP_BRANCH = "main"
 
 branch_name = "test_branch"
 

--- a/licenses/tests/test_utils.py
+++ b/licenses/tests/test_utils.py
@@ -458,8 +458,8 @@ class TestMisc(TestCase):
         )
 
     def test_cleanup_current_branch_output(self):
-        expected_list = ["some-branch", "another-branch", "develop"]
-        unmodified_list = ["some-branch", "* another-branch", "develop"]
+        expected_list = ["some-branch", "another-branch", "main"]
+        unmodified_list = ["some-branch", "* another-branch", "main"]
         self.assertEqual(
             cleanup_current_branch_output(unmodified_list), expected_list
         )

--- a/licenses/utils.py
+++ b/licenses/utils.py
@@ -296,13 +296,13 @@ def cleanup_current_branch_output(branch_list: list) -> list:
 
     for example: git branch --list
         some-branch
-        * develop
+        * main
 
-        branch-list = ['some-branch', '* develop']
+        branch-list = ['some-branch', '* main']
 
     The asterisks is attached to the current branch, and we want to remove
     this:
-        branch-list = ['some-branch' 'develop']
+        branch-list = ['some-branch' 'main']
 
     Arguments:
         branch-list (list) list of git branches.


### PR DESCRIPTION
## Description
- Update to reflect `main` is now configured as *default branch* (here and in cc-licenses-data)
- `licenses/tests/test_git_utils.py`
  - Also update variable names and comments to increase clarity

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
