### PR TITLE
add --nogit to publish command

### DIFF
--- a/licenses/management/commands/publish.py
+++ b/licenses/management/commands/publish.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):
 
     def publish_branch(self, branch: str):
         """Workflow for publishing a single branch"""
-        print(f"Publishing branch {branch}")
+        self.stdout.write(f"Publishing branch {branch}")
         with git.Repo(settings.TRANSLATION_REPOSITORY_DIRECTORY) as repo:
             setup_local_branch(repo, branch)
             self.run_django_distill()
@@ -121,12 +121,12 @@ class Command(BaseCommand):
                         "Something went wrong, the repo is still dirty"
                     )
             else:
-                print(f"\n{branch} build dir is up to date.\n")
+                self.stdout.write(f"\n{branch} build dir is up to date.\n")
 
     def publish_all(self):
         """Workflow for checking branches and updating their build dir"""
         branch_list = list_open_translation_branches()
-        print(
+        self.stdout.write(
             f"\n\nChecking and updating build dirs for {len(branch_list)}"
             " translation branches\n\n"
         )
@@ -137,8 +137,8 @@ class Command(BaseCommand):
         self.options = options
         self.output_dir = os.path.abspath(settings.DISTILL_DIR)
         git_dir = os.path.abspath(settings.TRANSLATION_REPOSITORY_DIRECTORY)
-        print(f"git_dir: {git_dir}")
-        print(f"self.output_dir: {self.output_dir}")
+        self.stdout.write(f"git_dir: {git_dir}")
+        self.stdout.write(f"self.output_dir: {self.output_dir}")
         if not self.output_dir.startswith(git_dir):
             raise ImproperlyConfigured(
                 f"In Django settings, DISTILL_DIR must be inside "
@@ -148,14 +148,14 @@ class Command(BaseCommand):
             )
 
         self.relpath = os.path.relpath(self.output_dir, git_dir)
-        print(f"self.relpath: {self.relpath}")
+        self.stdout.write(f"self.relpath: {self.relpath}")
         self.push = not options["nopush"]
 
         if options.get("list_branches"):
             branches = list_open_translation_branches()
-            print("\n\nWhich branch are we publishing to?\n")
+            self.stdout.write("\n\nWhich branch are we publishing to?\n")
             for b in branches:
-                print(b)
+                self.stdout.write(b)
         elif options.get("nogit"):
             self.run_django_distill()
         elif options.get("branch_name"):

--- a/licenses/management/commands/publish.py
+++ b/licenses/management/commands/publish.py
@@ -46,12 +46,9 @@ class Command(BaseCommand):
         parser.add_argument(
             "-b",
             "--branch_name",
-            help=(
-                "Translation branch name to pull translations from "
-                "and push artifacts to.  Use --list_branches to see "
-                "available branch names.  With no option, all active "
-                "branches are published."
-            ),
+            help="Translation branch name to pull translations from and push"
+            " artifacts to. Use --list_branches to see available branch names."
+            " With no option, all active branches are published.",
         )
         parser.add_argument(
             "-l",
@@ -63,6 +60,12 @@ class Command(BaseCommand):
             "--nopush",
             action="store_true",
             help="Update the local branches, but don't push upstream.",
+        )
+        parser.add_argument(
+            "--nogit",
+            action="store_true",
+            help="Update the local files without any attempt to manage them in"
+            " git (implies --nopush)",
         )
 
     def _quiet(self, *args, **kwargs):
@@ -134,7 +137,8 @@ class Command(BaseCommand):
         self.options = options
         self.output_dir = os.path.abspath(settings.DISTILL_DIR)
         git_dir = os.path.abspath(settings.TRANSLATION_REPOSITORY_DIRECTORY)
-
+        print(f"git_dir: {git_dir}")
+        print(f"self.output_dir: {self.output_dir}")
         if not self.output_dir.startswith(git_dir):
             raise ImproperlyConfigured(
                 f"In Django settings, DISTILL_DIR must be inside "
@@ -144,6 +148,7 @@ class Command(BaseCommand):
             )
 
         self.relpath = os.path.relpath(self.output_dir, git_dir)
+        print(f"self.relpath: {self.relpath}")
         self.push = not options["nopush"]
 
         if options.get("list_branches"):
@@ -151,6 +156,8 @@ class Command(BaseCommand):
             print("\n\nWhich branch are we publishing to?\n")
             for b in branches:
                 print(b)
+        elif options.get("nogit"):
+            self.run_django_distill()
         elif options.get("branch_name"):
             self.publish_branch(options["branch_name"])
         else:


### PR DESCRIPTION
## Description
- Add --nogit to publish command (ex. `pipenv run ./manage.py publish --nogit`). This makes it easier to iterate on template changes, etc.
- Use `self.stdout.write()` instead of `print()` per [Writing custom django-admin commands | Django documentation | Django](https://docs.djangoproject.com/en/2.2/howto/custom-management-commands/)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
