### PR TITLE
Various clean-ups and clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,24 +268,19 @@ command line.
 To upload/download translation files to/from Transifex, you'll need an account
 there with access to these translations. Then follow [these
 instructions](https://docs.transifex.com/api/introduction#authentication) to
-get an API token, and set TRANSIFEX_API_TOKEN in your environment with its
+get an API token, and set `TRANSIFEX_API_TOKEN` in your environment with its
 value.
 
-The cc-licenses-data repo should be cloned next to the cc-licenses repo.  (It
-can be elsewhere, then you need to set TRANSLATION_REPOSITORY_DIRECTORY to its
-location.) Be sure to clone using a URL that starts with `git@github...` and
-not `https://github...`, or you won't be able to push to it.
-
-When the site is deployed, to enable pushing and pulling the licenses data repo
-with Github, create an ssh deploy key for the cc-licenses-data repo with write
-permissions, and put the private key file (not password protected) somewhere
-safe, owned by www-data, and readable only by its owner (0o400). Then in
-settings, make TRANSLATION_REPOSITORY_DEPLOY_KEY be the full path to that
-deploy key file.
+The cc-licenses-data repo should be cloned next to the cc-licenses repo. (It
+can be elsewhere, then you need to set `TRANSLATION_REPOSITORY_DIRECTORY` to
+its location.) Be sure to clone using a URL that starts with `git@github...`
+and not `https://github...`, or you won't be able to push to it.
 
 Now arrange for `pipenv run ./manage.py check_for_translation_updates` to be
 run hourly (or the equivalent with the appropriate virtualenv and env
 variarables set).
+
+Also see [Publishing changes to git repo](#publishing-changes-to-git-repo).
 
 
 ## When translations have been updated in Transifex
@@ -430,6 +425,16 @@ it'll both commit and push them. Just be aware that it won't try to push unless
 it has just committed some changes, so if upstream is already behind and
 running publish doesn't make any new changes, you'll still have to push
 manually to get upstream updated.
+
+
+### Publishing changes to git repo
+
+When the site is deployed, to enable pushing and pulling the licenses data repo
+with Github, create an ssh deploy key for the cc-licenses-data repo with write
+permissions, and put the private key file (not password protected) somewhere
+safe, owned by www-data, and readable only by its owner (0o400). Then in
+settings, make `TRANSLATION_REPOSITORY_DEPLOY_KEY` be the full path to that
+deploy key file.
 
 
 ## License

--- a/cc_licenses/settings/local.example.py
+++ b/cc_licenses/settings/local.example.py
@@ -2,3 +2,4 @@
 from cc_licenses.settings.dev import *  # noqa: F401, F403
 
 # Override settings here
+# TRANSLATION_REPOSITORY_DEPLOY_KEY = "/path/to/ssh/private/key"

--- a/cc_licenses/templates/base.html
+++ b/cc_licenses/templates/base.html
@@ -1,7 +1,6 @@
-{% load static from staticfiles %}
-{% load i18n bidi %}
-<!DOCTYPE html>
-{% get_current_language as LANGUAGE_CODE %}{# View will have set current language #}
+<!DOCTYPE html>{% load bidi i18n %}{% load static from staticfiles %}
+{# View will have set current language #}
+{% get_current_language as LANGUAGE_CODE %}
 {% get_language_info for LANGUAGE_CODE as lang %}
 <html lang="{{ lang.code }}" class="no-js" dir="{% if lang.bidi %}rtl{% else %}ltr{% endif %}">
 <head about="{% block about %} {% endblock %}">
@@ -12,10 +11,12 @@
     <meta name="author" content="{% block meta-author %}{% endblock %}">
     <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
     <meta name="keywords" content="{% block meta-keywords %}{% endblock %}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
-    {# We're pinning vocabulary v2020.11.1 because v2020.11.2 had a change that broke headers for this site. #}
-    {# So far, I've been unable to find any documentation about it other than the warning in the release #}
-    {# notes that there was a breaking change. #}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">{% comment %}{#
+    We're pinning vocabulary v2020.11.1 because v2020.11.2 had a change that
+    broke headers for this site. So far, I've been unable to find any
+    documentation about it other than the warning in the release notes that
+    there was a breaking change.
+    #}{% endcomment %}
     <link rel="stylesheet" href="https://unpkg.com/@creativecommons/vocabulary@v2020.11.1/css/vocabulary.css">
 </head>
 <body typeoff="cc:License">

--- a/cc_licenses/templates/includes/deed_40_body.html
+++ b/cc_licenses/templates/includes/deed_40_body.html
@@ -31,7 +31,7 @@
   <div class="columns is-multiline">
     {# Forloop  - populate content from deed model#}
     <div class="column is-1">
-      {% include 'includes/snippet/icon.html' with icon_type='cc-by' %}
+{% include 'includes/snippet/icon.html' with icon_type='cc-by' %}
     </div>
     <div class="column is-11">
       <p class="has-text-black body-big padding-bottom-normal">
@@ -43,7 +43,7 @@
 
   {% if license.prohibits_commercial_use %}
     <div class="column is-1">
-      {% include 'includes/snippet/icon.html' with icon_type='cc-nc' %}
+{% include 'includes/snippet/icon.html' with icon_type='cc-nc' %}
     </div>
     <div class="column is-11">
       <p class="has-text-black body-big padding-bottom-normal">
@@ -55,7 +55,7 @@
 
   {% if license.requires_share_alike %}
     <div class="column is-1">
-      {% include 'includes/snippet/icon.html' with icon_type='cc-sa' %}
+{% include 'includes/snippet/icon.html' with icon_type='cc-sa' %}
     </div>
     <div class="column is-11">
       <p class="has-text-black body-big padding-bottom-normal">
@@ -66,7 +66,7 @@
 
 {% if not license.permits_derivative_works %}
     <div class="column is-1">
-      {% include 'includes/snippet/icon.html' with icon_type='cc-nd' %}
+{% include 'includes/snippet/icon.html' with icon_type='cc-nd' %}
     </div>
     <div class="column is-11">
       <p class="has-text-black body-big padding-bottom-normal">

--- a/cc_licenses/templates/includes/licenses_header.html
+++ b/cc_licenses/templates/includes/licenses_header.html
@@ -5,9 +5,7 @@
   <h2 class="is-vcentered">
     {# Icon Sections #}
     <span class="padding-{% end %}-bigger">
-      {% for code in license.logos %}
-        {% include 'includes/snippet/icon.html' with icon_type=code additional_classes='padding-bottom-small' is_license_header=True %}
-      {% endfor %}
+{% for code in license.logos %}{% include 'includes/snippet/icon.html' with icon_type=code additional_classes='padding-bottom-small' is_license_header=True %}{% endfor %}
     </span>
 
     {{ legalcode.fat_code }} {#  e.g. CC BY-NC 4.0 #}
@@ -20,9 +18,7 @@
   <h2 class="has-text-centered">
     {# Icon Sections #}
     <span>
-      {% for code in license.logos %}
-        {% include 'includes/snippet/icon.html' with icon_type=code additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_license_header=True %}
-      {% endfor %}
+{% for code in license.logos %}{% include 'includes/snippet/icon.html' with icon_type=code additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' is_license_header=True %}{% endfor %}
       </span>
   </h2>
   <h2 class="has-text-centered is-hidden-touch is-hidden-desktop-only padding-{% start %}-normal">{{ legalcode.fat_code }}</h2>

--- a/cc_licenses/templates/includes/snippet/icon.html
+++ b/cc_licenses/templates/includes/snippet/icon.html
@@ -1,9 +1,9 @@
-{% load bidi %}
+{% load bidi %}{% comment %}{#
+This snippet handles media queries for the icons within deed_body and
+sampling_deed templates
 
-{# This snippet handles media queries for the icons within deed_body #}
-{# and sampling_deed templates #}
-
-{% if is_icon_header %}{# next to license title just above text of license itself #}
+next to license title just above text of license itself
+#}{% endcomment %}{% if is_icon_header %}
 <i
   class="{{ icon_type }} icon has-text-black has-background-white is-size-1 is-hidden-touch margin-normal {{ additional_classes }}"
 ></i>

--- a/cc_licenses/templates/includes/snippet/icon_header_snippet.html
+++ b/cc_licenses/templates/includes/snippet/icon_header_snippet.html
@@ -6,9 +6,7 @@
 <h3 class="is-hidden-touch">
   {# Icon Sections #}
     <span class="padding-{% end %}-bigger">
-      {% for code in license.logos %}
-        {% include 'includes/snippet/icon.html' with icon_type=code is_icon_header=True additional_classes='padding-bottom-small' %}
-      {% endfor %}
+{% for code in license.logos %}{% include 'includes/snippet/icon.html' with icon_type=code is_icon_header=True additional_classes='padding-bottom-small' %}{% endfor %}
     </span>
   {{ legalcode.fat_code }}
 </h3>
@@ -18,9 +16,7 @@
 <h3 class="is-hidden-desktop is-hidden-mobile">
   {# Icon Sections #}
     <span class="padding-{% end %}-big">
-      {% for code in license.logos %}
-        {% include 'includes/snippet/icon.html' with icon_type=code is_icon_header=True additional_classes='padding-bottom-small' %}
-      {% endfor %}
+{% for code in license.logos %}{% include 'includes/snippet/icon.html' with icon_type=code is_icon_header=True additional_classes='padding-bottom-small' %}{% endfor %}
     </span>
     {{ legalcode.fat_code }}
 </h3>
@@ -29,10 +25,7 @@
 <h3 class="is-hidden-tablet">
   {# Icon Sections #}
     <span>
-      {% for code in license.logos %}
-        {% include 'includes/snippet/icon.html' with icon_type=code is_icon_header=True additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' %}
-      {% endfor %}
-
+{% for code in license.logos %}{% include 'includes/snippet/icon.html' with icon_type=code is_icon_header=True additional_classes='padding-bottom-small margin-horizontal-smaller margin-vertical-small' %}{% endfor %}
     </span>
 </h3>
 <h4 class="has-text-centered is-hidden-tablet padding-{% start %}-normal">{{ legalcode.fat_code }}</h4>

--- a/licenses/git_utils.py
+++ b/licenses/git_utils.py
@@ -13,22 +13,17 @@ logger.setLevel(logging.DEBUG)
 
 
 def run_git(repo: git.Repo, command: List[str]):
-    # print(" ".join(command))
     result = subprocess.run(command, cwd=repo.working_tree_dir)
     if result.returncode != 0:
         raise Exception("Something went wrong running git")
 
 
-def setup_to_call_git(env=None):
+def setup_to_call_git():
     """
-    Call this to set the environment before starting to use git.
+    Call this to set the environment (os.environ) before starting to use git.
     Safe to call any number of times.
-
-    If env is none, it'll use os.environ, which is the usual case.
-    You can pass a dictionary as env for testing.
     """
-    if env is None:
-        env = os.environ
+    env = os.environ
     # Use custom ssh command to use the deploy key when pushing
     if "GIT_SSH" not in env:
         env["GIT_SSH"] = os.path.join(settings.ROOT_DIR, "ssh_wrapper.sh")

--- a/licenses/git_utils.py
+++ b/licenses/git_utils.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import subprocess
+import sys
 from typing import List
 
 # Third-party
@@ -91,7 +92,18 @@ def setup_local_branch(repo: git.Repo, branch_name: str):
     THIS DISCARDS ANY LOCAL CHANGES!!!!
     """
     origin = repo.remotes.origin
-    origin.fetch()
+    try:
+        origin.fetch()
+    except git.exc.GitCommandError as e:
+        if "protocol error" in e.stderr:
+            print(
+                f"ERROR: git origin.fetch() {e.stderr.strip()}."
+                " Check git remote access/authentication.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        else:
+            raise
 
     # Hard reset in case the repo is dirty
     repo.head.reset(index=True, working_tree=True)

--- a/licenses/tests/test_git_utils.py
+++ b/licenses/tests/test_git_utils.py
@@ -15,6 +15,7 @@ from licenses.git_utils import (
     commit_and_push_changes,
     get_branch,
     push_current_branch,
+    run_git,
     setup_local_branch,
     setup_to_call_git,
 )
@@ -130,6 +131,10 @@ class SetupLocalBranchTest(GitTestMixin, TestCase):
 
 @override_settings(TRANSLATION_REPOSITORY_DIRECTORY="/trans/repo")
 class CommitAndPushChangesTest(GitTestMixin, TestCase):
+    def test_run_git_exception(self):
+        with self.assertRaises(Exception):
+            run_git(self.origin_repo, ["git", "invalidcommand"])
+
     def test_push(self):
         # Just make sure our helper function does what it should
         mock_repo = mock.MagicMock()

--- a/licenses/tests/test_git_utils.py
+++ b/licenses/tests/test_git_utils.py
@@ -133,7 +133,7 @@ class SetupLocalBranchTest(GitTestMixin, TestCase):
 class CommitAndPushChangesTest(GitTestMixin, TestCase):
     def test_run_git_exception(self):
         with self.assertRaises(Exception):
-            run_git(self.origin_repo, ["git", "invalidcommand"])
+            run_git(self.origin_repo, ["git", "TestInvalidCommand"])
 
     def test_push(self):
         # Just make sure our helper function does what it should

--- a/manage.py
+++ b/manage.py
@@ -2,8 +2,17 @@
 # Standard library
 import os
 import sys
+import traceback
 
-if __name__ == "__main__":
+
+class ScriptError(Exception):
+    def __init__(self, message, code=None):
+        self.code = code if code else 1
+        message = "({}) {}".format(self.code, message)
+        super(ScriptError, self).__init__(message)
+
+
+def main():
     if "DATABASE_URL" in os.environ:
         # Dokku or similar
         os.environ.setdefault(
@@ -18,3 +27,21 @@ if __name__ == "__main__":
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit as e:
+        sys.exit(e.code)
+    except KeyboardInterrupt:
+        print("INFO (130) Halted via KeyboardInterrupt.", file=sys.stderr)
+        sys.exit(130)
+    except ScriptError:
+        error_type, error_value, error_traceback = sys.exc_info()
+        print("CRITICAL {}".format(error_value), file=sys.stderr)
+        sys.exit(error_value.code)
+    except Exception:
+        print("ERROR (1) Unhandled exception:", file=sys.stderr)
+        print(traceback.print_exc(), file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Description
Various quality of life updates for issues I encountered while configuring local dev to publish:
- improve error and exception handling
- improve `TRANSLATION_REPOSITORY_DEPLOY_KEY` related documentation
- increase git_utils test coverage
- reduce HTML template whitespace to reduce delta from previous publish
- update SSH wrapper
   - add test for PROJECT_ROOT environment variable
   - simply environment variable present verification
   - remove unnecessary exec
   - improve ssh options
   - document testing command line

(For most recent publish, see [Updated built HTML files · creativecommons/cc-licenses-data@04ead6f](https://github.com/creativecommons/cc-licenses-data/commit/04ead6fd9a0cb88191b8ea984724d09d970440ff))

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
