### PR TITLE
Update publish layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Python version 3.7 is used for parity with Debian GNU/Linux 10 (buster).
 
 ## Development Server
 
-You should be able to run the development server via:
+You should be able to run the development server
+([127.0.0.1:8000](http://127.0.0.1:8000/)) via:
 ```shell
 pipenv run ./manage.py runserver
 ```

--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -267,7 +267,7 @@ TRANSLATION_REPOSITORY_DIRECTORY = os.getenv(
 )
 
 # django-distill settings
-DISTILL_DIR = f"{TRANSLATION_REPOSITORY_DIRECTORY}/build/"
+DISTILL_DIR = f"{TRANSLATION_REPOSITORY_DIRECTORY}/docs/"
 
 # Django translations are in the translation repo directory, under "locale".
 # License translations are in the translation repo directory, under

--- a/licenses/tests/test_templatetags.py
+++ b/licenses/tests/test_templatetags.py
@@ -6,17 +6,33 @@ from django.urls import get_resolver
 from licenses.models import build_deed_url, build_license_url
 from licenses.templatetags.license_tags import (
     current_letter,
+    license_codes,
     next_letter,
     reset_letters,
 )
 
 
 class LicenseTagsTest(TestCase):
+    def test_license_codes(self):
+        expected = ["by", "by-nc", "by-nc-nd", "by-nc-sa", "by-nd", "by-sa"]
+        data = [
+            {"license_code": "by-nc-nd"},
+            {"license_code": "by-nc"},
+            {"license_code": "by-sa"},
+            {"license_code": "by"},
+            {"license_code": "by-nc-sa"},
+            {"license_code": "by"},
+            {"license_code": "by-nd"},
+        ]
+        self.assertEqual(expected, license_codes(data))
+
     def test_reset_letters(self):
         reset_letters("lowercase")
         self.assertEqual("a", next_letter())
         reset_letters("uppercase")
         self.assertEqual("A", next_letter())
+        with self.assertRaises(ValueError):
+            reset_letters("InvalidValue")
 
     def test_next_letter(self):
         reset_letters("lowercase")

--- a/licenses/tests/test_utils.py
+++ b/licenses/tests/test_utils.py
@@ -31,17 +31,21 @@ from .factories import LegalCodeFactory, LicenseFactory
 
 class SaveURLAsStaticFileTest(TestCase):
     def test_save_bytes_to_file(self):
-        filepath = None
         try:
-            tmpfile = tempfile.NamedTemporaryFile()
-            filename = tmpfile.name
+            tmpdir = tempfile.TemporaryDirectory()
+            filename = os.path.join(tmpdir.name, "level1")
             save_bytes_to_file(b"abcxyz", filename)
-            tmpfile.seek(0)
-            content = tmpfile.read()
+            with open(filename, "rb") as f:
+                content = f.read()
+            self.assertEqual(b"abcxyz", content)
+
+            filename = os.path.join(tmpdir.name, "level1", "level2")
+            save_bytes_to_file(b"abcxyz", filename)
+            with open(filename, "rb") as f:
+                content = f.read()
             self.assertEqual(b"abcxyz", content)
         finally:
-            if filepath is not None:
-                os.remove(filepath)
+            tmpdir.cleanup()
 
     def test_save_url_as_static_file_not_200(self):
         output_dir = "/output"

--- a/licenses/tests/test_utils.py
+++ b/licenses/tests/test_utils.py
@@ -1,6 +1,7 @@
 # Standard library
 import os
 import tempfile
+from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -19,6 +20,7 @@ from licenses.utils import (
     get_code_from_jurisdiction_url,
     get_license_url_from_legalcode_url,
     parse_legalcode_filename,
+    relative_symlink,
     save_bytes_to_file,
     save_dict_to_pofile,
     save_url_as_static_file,
@@ -36,14 +38,44 @@ class SaveURLAsStaticFileTest(TestCase):
             filename = os.path.join(tmpdir.name, "level1")
             save_bytes_to_file(b"abcxyz", filename)
             with open(filename, "rb") as f:
-                content = f.read()
-            self.assertEqual(b"abcxyz", content)
+                contents = f.read()
+            self.assertEqual(b"abcxyz", contents)
 
             filename = os.path.join(tmpdir.name, "level1", "level2")
             save_bytes_to_file(b"abcxyz", filename)
             with open(filename, "rb") as f:
-                content = f.read()
-            self.assertEqual(b"abcxyz", content)
+                contents = f.read()
+            self.assertEqual(b"abcxyz", contents)
+        finally:
+            tmpdir.cleanup()
+
+    def test_relative_symlink(self):
+        try:
+            tmpdir = tempfile.TemporaryDirectory()
+            # symlink link1 => source1 and verify by reading link1
+            contents1 = b"111"
+            source1 = os.path.join(tmpdir.name, "source1")
+            with open(source1, "wb") as f:
+                f.write(contents1)
+            with mock.patch("sys.stdout", new=StringIO()) as mock_out:
+                relative_symlink(tmpdir.name, source1, "link1")
+                self.assertEqual(mock_out.getvalue().strip(), "^link1")
+            with open(os.path.join(tmpdir.name, "link1"), "rb") as f:
+                contents = f.read()
+            self.assertEqual(contents1, contents)
+            # symlink link2 => xx/source2 and verify by reading link2
+            subdir = os.path.join(tmpdir.name, "xx")
+            os.makedirs(subdir, mode=0o755)
+            contents2 = b"222"
+            source2 = os.path.join(subdir, "source1")
+            with open(source2, "wb") as f:
+                f.write(contents2)
+            with mock.patch("sys.stdout", new=StringIO()) as mock_out:
+                relative_symlink(tmpdir.name, source2, "../link2")
+                self.assertEqual(mock_out.getvalue().strip(), "^link2")
+            with open(os.path.join(tmpdir.name, "link2"), "rb") as f:
+                contents = f.read()
+            self.assertEqual(contents2, contents)
         finally:
             tmpdir.cleanup()
 
@@ -93,7 +125,11 @@ class SaveURLAsStaticFileTest(TestCase):
         url = "/"
 
         with mock.patch("licenses.utils.save_bytes_to_file"):
-            save_url_as_static_file(output_dir, url, "/output/home.html")
+            with mock.patch("sys.stdout", new=StringIO()) as mock_out:
+                save_url_as_static_file(output_dir, url, "/output/home.html")
+                self.assertEqual(
+                    mock_out.getvalue().strip(), "/output/home.html"
+                )
 
     def test_save_url_as_static_file_200(self):
         output_dir = "/output"
@@ -119,7 +155,11 @@ class SaveURLAsStaticFileTest(TestCase):
                 mock_resolve.return_value = MockResolverMatch(
                     func=mock_metadata_view
                 )
-                save_url_as_static_file(output_dir, url, relpath)
+                with mock.patch("sys.stdout", new=StringIO()) as mock_out:
+                    save_url_as_static_file(output_dir, url, relpath)
+                    self.assertEqual(
+                        mock_out.getvalue().strip(), "licenses/metadata.yaml"
+                    )
 
         self.assertEqual([call(url)], mock_resolve.call_args_list)
         self.assertEqual(

--- a/licenses/utils.py
+++ b/licenses/utils.py
@@ -55,8 +55,27 @@ def save_url_as_static_file(output_dir, url, relpath):
     if hasattr(rsp, "render"):
         rsp.render()
     output_filename = os.path.join(output_dir, relpath)
-    print(f"{url} -> {output_filename}")
+    print(f"    {relpath}")
     save_bytes_to_file(rsp.content, output_filename)
+
+
+def relative_symlink(src1, src2, dst):
+    padding = " " * len(os.path.dirname(src2))
+    src = os.path.abspath(os.path.join(src1, src2))
+    dir_path, src_file = os.path.split(src)
+    # Handle ../symlinks for xu jurisdiction
+    if dst.startswith("../"):
+        __, dst = os.path.split(dst)
+        os.path.split(src2)
+        dir_path, subdir = os.path.split(dir_path)
+        src_file = os.path.join(subdir, src_file)
+        padding = padding[:-3]
+    dir_fd = os.open(dir_path, os.O_RDONLY)
+    try:
+        os.symlink(src_file, dst, dir_fd=dir_fd)
+        print(f"    {padding}^{dst}")
+    finally:
+        os.close(dir_fd)
 
 
 def get_code_from_jurisdiction_url(url):


### PR DESCRIPTION
## Description
Update publish layout
- Refactor output organization to better match production URLs (also adds symlinks). This will not only make hosting easier, but will also make the data repository useful without special hosting (ex. it could be served via GitHub pages)
- slightly increased test coverage

### Publish Organization Excerpt
Symlinks are noted with `^`. Note that unported (`xu` jurisdiction) have symlinks in the parent (ex. `docs/licenses/by-nc-nd/3.0/index.html`):
```
cc-licenses-data/docs
    licenses/by-nc-nd/3.0/xu/deed.en
                         ^deed.en
                         ^deed
                         ^index.html
    licenses/by-nc-nd/3.0/xu/legalcode.en
                         ^legalcode.en
                         ^legalcode
    licenses/by-nc-nd/3.0/am/deed.hy
                            ^deed
                            ^index.html
    licenses/by-nc-nd/3.0/am/legalcode.hy
                            ^legalcode
    licenses/by-nc-nd/3.0/at/deed.de
                            ^deed
                            ^index.html
    licenses/by-nc-nd/3.0/at/legalcode.de
                            ^legalcode
    licenses/by-nc-nd/3.0/au/deed.en
                            ^deed
                            ^index.html
    licenses/by-nc-nd/3.0/au/legalcode.en
                            ^legalcode
    licenses/by-nc-nd/3.0/az/deed.az
                            ^deed
                            ^index.html
    licenses/by-nc-nd/3.0/az/legalcode.az
                            ^legalcode
    licenses/by-nc-nd/3.0/br/deed.pt-br
                            ^deed
                            ^index.html
    licenses/by-nc-nd/3.0/br/legalcode.pt-br
                            ^legalcode
    licenses/by-nc-nd/3.0/ca/deed.en
                            ^deed
                            ^index.html
    licenses/by-nc-nd/3.0/ca/legalcode.en
                            ^legalcode
    licenses/by-nc-nd/3.0/ca/deed.fr
    licenses/by-nc-nd/3.0/ca/legalcode.fr
```

## Tests
New coverage with PR:
```
Name                    Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------
i18n/utils.py              72      1      8      1    98%   125->126, 126
licenses/git_utils.py      81      5     36      3    91%   62->exit, 97-106, 116->118, 132->137
licenses/models.py        269      1     74      1    99%   636->639, 639
licenses/transifex.py     201      2     42      3    98%   47, 98->99, 99, 252->exit, 285->293
licenses/views.py          90      1     22      2    97%   194->195, 195, 283->292
-------------------------------------------------------------------
TOTAL                    1008     10    292     10    98%
```

Old coverage without PR:
```
Name                                    Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------
i18n/utils.py                              72      1      8      1    98%   125->126, 126
licenses/git_utils.py                      81      5     36      3    91%   62->exit, 97-106, 116->118, 132->137
licenses/models.py                        249      1     56      2    99%   435->438, 573->576, 576
licenses/templatetags/license_tags.py      25      2      6      1    84%   25, 37->40, 40
licenses/transifex.py                     201      2     42      3    98%   47, 98->99, 99, 252->exit, 285->293
licenses/utils.py                         162      1     78      1    99%   25->26, 26
licenses/views.py                          90      1     22      2    97%   194->195, 195, 283->292
-----------------------------------------------------------------------------------
TOTAL                                     973     13    272     13    98%
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
