### PR TITLE
Moar coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
 
       - id: coverage-report
         name: 'Confirm test coverage'
-        entry: pipenv run coverage report -m --fail-under 98
+        entry: pipenv run coverage report
         language: system
         types: ["file", "python", "text"]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       # This test fails if web server is not running
       - id: coverage-test
         name: 'Run Django tests'
-        entry: pipenv run coverage run manage.py test --noinput --keepdb
+        entry: pipenv run coverage run --timid manage.py test --noinput --keepdb
         language: system
         types: ["file", "python", "text"]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       # This test fails if web server is not running
       - id: coverage-test
         name: 'Run Django tests'
-        entry: pipenv run coverage run --timid manage.py test --noinput --keepdb
+        entry: pipenv run coverage run manage.py test --noinput --keepdb
         language: system
         types: ["file", "python", "text"]
         pass_filenames: false

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -265,11 +265,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
-                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
+                "sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee",
+                "sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.3.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.4"
         },
         "beautifulsoup4": {
             "hashes": [
@@ -409,11 +409,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:08c4cfbfd498c0e90aff6741771c01803d894013df858db6a573182c6a47951f",
-                "sha256:20c6e4253b73ef2a783d38e085e7c8d8916295fff31c7403116d2af8f908f7ca"
+                "sha256:225314932de94c282b096f6c3aac32db50119922747ac09a8350310da44241e5",
+                "sha256:fe4bc214ba448ca52b20a0ee0ed16ded3e1ddce7874f2a95cd321d21e2e388d9"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==7.0.1"
+            "version": "==8.0.0"
         },
         "filelock": {
             "hashes": [
@@ -638,11 +638,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:94c82f1bf5899d56edb1d926732f4e75a7df29a0c8c092559c77420c9d62428b",
-                "sha256:de55c5c72ce80d79106e48beb1b54104d16495ce7f95b0c7b13d4784193a00af"
+                "sha256:029d53cb83c241fe7d66eeee1e24db426f42c858f15a38d20bcefd8d8e05c9da",
+                "sha256:46b6ffbab37986c47d0a35e40906ae029376deed89a0eb2e446fb6e67b220427"
             ],
             "index": "pypi",
-            "version": "==2.11.1"
+            "version": "==2.12.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -712,49 +712,49 @@
         },
         "regex": {
             "hashes": [
-                "sha256:07ef35301b4484bce843831e7039a84e19d8d33b3f8b2f9aab86c376813d0139",
-                "sha256:13f50969028e81765ed2a1c5fcfdc246c245cf8d47986d5172e82ab1a0c42ee5",
-                "sha256:14de88eda0976020528efc92d0a1f8830e2fb0de2ae6005a6fc4e062553031fa",
-                "sha256:159fac1a4731409c830d32913f13f68346d6b8e39650ed5d704a9ce2f9ef9cb3",
-                "sha256:18e25e0afe1cf0f62781a150c1454b2113785401ba285c745acf10c8ca8917df",
-                "sha256:201e2619a77b21a7780580ab7b5ce43835e242d3e20fef50f66a8df0542e437f",
-                "sha256:360a01b5fa2ad35b3113ae0c07fb544ad180603fa3b1f074f52d98c1096fa15e",
-                "sha256:39c44532d0e4f1639a89e52355b949573e1e2c5116106a395642cbbae0ff9bcd",
-                "sha256:3d9356add82cff75413bec360c1eca3e58db4a9f5dafa1f19650958a81e3249d",
-                "sha256:3d9a7e215e02bd7646a91fb8bcba30bc55fd42a719d6b35cf80e5bae31d9134e",
-                "sha256:4651f839dbde0816798e698626af6a2469eee6d9964824bb5386091255a1694f",
-                "sha256:486a5f8e11e1f5bbfcad87f7c7745eb14796642323e7e1829a331f87a713daaa",
-                "sha256:4b8a1fb724904139149a43e172850f35aa6ea97fb0545244dc0b805e0154ed68",
-                "sha256:4c0788010a93ace8a174d73e7c6c9d3e6e3b7ad99a453c8ee8c975ddd9965643",
-                "sha256:4c2e364491406b7888c2ad4428245fc56c327e34a5dfe58fd40df272b3c3dab3",
-                "sha256:575a832e09d237ae5fedb825a7a5bc6a116090dd57d6417d4f3b75121c73e3be",
-                "sha256:5770a51180d85ea468234bc7987f5597803a4c3d7463e7323322fe4a1b181578",
-                "sha256:633497504e2a485a70a3268d4fc403fe3063a50a50eed1039083e9471ad0101c",
-                "sha256:63f3ca8451e5ff7133ffbec9eda641aeab2001be1a01878990f6c87e3c44b9d5",
-                "sha256:709f65bb2fa9825f09892617d01246002097f8f9b6dde8d1bb4083cf554701ba",
-                "sha256:808404898e9a765e4058bf3d7607d0629000e0a14a6782ccbb089296b76fa8fe",
-                "sha256:882f53afe31ef0425b405a3f601c0009b44206ea7f55ee1c606aad3cc213a52c",
-                "sha256:8bd4f91f3fb1c9b1380d6894bd5b4a519409135bec14c0c80151e58394a4e88a",
-                "sha256:8e65e3e4c6feadf6770e2ad89ad3deb524bcb03d8dc679f381d0568c024e0deb",
-                "sha256:976a54d44fd043d958a69b18705a910a8376196c6b6ee5f2596ffc11bff4420d",
-                "sha256:a0d04128e005142260de3733591ddf476e4902c0c23c1af237d9acf3c96e1b38",
-                "sha256:a0df9a0ad2aad49ea3c7f65edd2ffb3d5c59589b85992a6006354f6fb109bb18",
-                "sha256:a2ee026f4156789df8644d23ef423e6194fad0bc53575534101bb1de5d67e8ce",
-                "sha256:a59a2ee329b3de764b21495d78c92ab00b4ea79acef0f7ae8c1067f773570afa",
-                "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6",
-                "sha256:b98bc9db003f1079caf07b610377ed1ac2e2c11acc2bea4892e28cc5b509d8d5",
-                "sha256:b9d8d286c53fe0cbc6d20bf3d583cabcd1499d89034524e3b94c93a5ab85ca90",
-                "sha256:bcd945175c29a672f13fce13a11893556cd440e37c1b643d6eeab1988c8b209c",
-                "sha256:c66221e947d7207457f8b6f42b12f613b09efa9669f65a587a2a71f6a0e4d106",
-                "sha256:c782da0e45aff131f0bed6e66fbcfa589ff2862fc719b83a88640daa01a5aff7",
-                "sha256:cb4ee827857a5ad9b8ae34d3c8cc51151cb4a3fe082c12ec20ec73e63cc7c6f0",
-                "sha256:d47d359545b0ccad29d572ecd52c9da945de7cd6cf9c0cfcb0269f76d3555689",
-                "sha256:dc9963aacb7da5177e40874585d7407c0f93fb9d7518ec58b86e562f633f36cd",
-                "sha256:ea2f41445852c660ba7c3ebf7d70b3779b20d9ca8ba54485a17740db49f46932",
-                "sha256:f5d0c921c99297354cecc5a416ee4280bd3f20fd81b9fb671ca6be71499c3fdf",
-                "sha256:f85d6f41e34f6a2d1607e312820971872944f1661a73d33e1e82d35ea3305e14"
+                "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5",
+                "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79",
+                "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31",
+                "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500",
+                "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11",
+                "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14",
+                "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3",
+                "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439",
+                "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c",
+                "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82",
+                "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711",
+                "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093",
+                "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a",
+                "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb",
+                "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8",
+                "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17",
+                "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000",
+                "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d",
+                "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480",
+                "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc",
+                "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0",
+                "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9",
+                "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765",
+                "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e",
+                "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a",
+                "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07",
+                "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f",
+                "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac",
+                "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7",
+                "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed",
+                "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968",
+                "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7",
+                "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2",
+                "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4",
+                "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87",
+                "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8",
+                "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10",
+                "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29",
+                "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605",
+                "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6",
+                "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"
             ],
-            "version": "==2021.3.17"
+            "version": "==2021.4.4"
         },
         "requests": {
             "hashes": [

--- a/licenses/git_utils.py
+++ b/licenses/git_utils.py
@@ -14,8 +14,16 @@ logger.setLevel(logging.DEBUG)
 
 
 def run_git(repo: git.Repo, command: List[str]):
-    result = subprocess.run(command, cwd=repo.working_tree_dir)
-    if result.returncode != 0:
+    result = subprocess.run(
+        command,
+        cwd=repo.working_tree_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.returncode == 0:
+        print(result.stdout.decode("utf-8"), end="")
+    else:
+        print(result.stdout.decode("utf-8"), end="", file=sys.stderr)
         raise Exception("Something went wrong running git")
 
 

--- a/licenses/tests/test_git_utils.py
+++ b/licenses/tests/test_git_utils.py
@@ -1,6 +1,7 @@
 # Standard library
 import os
 import subprocess
+from io import StringIO
 from tempfile import TemporaryDirectory
 from unittest import mock
 
@@ -131,9 +132,21 @@ class SetupLocalBranchTest(GitTestMixin, TestCase):
 
 @override_settings(TRANSLATION_REPOSITORY_DIRECTORY="/trans/repo")
 class CommitAndPushChangesTest(GitTestMixin, TestCase):
-    def test_run_git_exception(self):
-        with self.assertRaises(Exception):
-            run_git(self.origin_repo, ["git", "TestInvalidCommand"])
+    def test_run_git_success(self):
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_out:
+            run_git(self.origin_repo, ["git", "--version"])
+            self.assertIn("git version", mock_out.getvalue())
+
+    def test_run_git_fail(self):
+        with self.assertRaises(Exception) as cm:
+            with mock.patch("sys.stderr", new_callable=StringIO) as mock_err:
+                run_git(self.origin_repo, ["git", "TestInvalidCommand"])
+                self.assertEqual(
+                    mock_err.getvalue().strip(),
+                    "git: 'TestInvalidCommand' is not a git command. See"
+                    " 'git --help'.",
+                )
+        self.assertEqual(str(cm.exception), "Something went wrong running git")
 
     def test_push(self):
         # Just make sure our helper function does what it should
@@ -198,6 +211,7 @@ class CommitAndPushChangesTest(GitTestMixin, TestCase):
         subprocess.run(
             ["git", "status"],
             cwd=self.local_repo_path,
+            stdout=subprocess.DEVNULL,
         )
 
         self.assertFalse(self.local_repo.is_dirty())

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -794,7 +794,8 @@ class LicenseModelTest(TestCase):
         TRANSLATION_REPOSITORY_DIRECTORY="/trans/repo",
     )
     def test_tx_upload_messages(self):
-        legalcode = LegalCodeFactory(language_code=DEFAULT_LANGUAGE_CODE)
+        language_code = "es"
+        legalcode = LegalCodeFactory(language_code=language_code)
         license = legalcode.license
         test_pofile = polib.POFile()
         with mock.patch.object(

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -1,6 +1,7 @@
 # Standard library
 import datetime
 import os
+from io import StringIO
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -17,7 +18,12 @@ from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import get_pofile_content
 from licenses.models import LegalCode, TranslationBranch
 from licenses.tests.factories import LegalCodeFactory, LicenseFactory
-from licenses.transifex import TransifexAuthRequests, TransifexHelper
+from licenses.transifex import (
+    LEGALCODES_KEY,
+    TransifexAuthRequests,
+    TransifexHelper,
+    _empty_branch_object,
+)
 
 TEST_PROJECT_SLUG = "proj"
 TEST_ORGANIZATION_SLUG = "org"
@@ -64,6 +70,27 @@ class DummyRepo:
 class TestTransifex(TestCase):
     def setUp(self):
         self.helper = TransifexHelper()
+
+    def test__empty_branch_object(self):
+        empty = _empty_branch_object()
+        self.assertEquals(empty, {LEGALCODES_KEY: []})
+
+    def test_transifexhelper_say(self):
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_out:
+            self.helper.say(0, "loud")
+            self.assertEqual(mock_out.getvalue().strip(), "loud")
+        with mock.patch("sys.stdout", new_callable=StringIO) as mock_out:
+            self.helper.say(2, "quiet")
+            self.assertEqual(mock_out.getvalue().strip(), "")
+
+    def test_clear_transifex_stats(self):
+        with self.assertRaises(AttributeError):
+            self.helper._stats
+        self.helper.clear_transifex_stats()
+        self.helper._stats = 1
+        self.helper.clear_transifex_stats()
+        with self.assertRaises(AttributeError):
+            self.helper._stats
 
     def test_request20_success(self):
         with mpo(self.helper.api_v20, "get") as mock_get:

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -252,7 +252,7 @@ class ViewLicenseTest(TestCase):
             rsp, "includes/legalcode_30_ported_license.html"
         )
         context = rsp.context
-        self.assertContains(rsp, '''lang="de"''')
+        self.assertContains(rsp, 'lang="de"')
         self.assertEqual(lc, context["legalcode"])
 
     def test_view_license_identifying_jurisdiction_default_language(self):
@@ -270,7 +270,7 @@ class ViewLicenseTest(TestCase):
             rsp, "includes/legalcode_30_ported_license.html"
         )
         context = rsp.context
-        self.assertContains(rsp, f'''lang="{language_code}"''')
+        self.assertContains(rsp, f'lang="{language_code}"')
         self.assertEqual(lc, context["legalcode"])
 
     def test_view_license(self):
@@ -285,11 +285,11 @@ class ViewLicenseTest(TestCase):
             self.assertTemplateUsed(rsp, "includes/legalcode_40_license.html")
             context = rsp.context
             self.assertEqual(lc, context["legalcode"])
-            self.assertContains(rsp, f'''lang="{language_code}"''')
+            self.assertContains(rsp, f'lang="{language_code}"')
             if language_code == "es":
-                self.assertContains(rsp, '''dir="ltr"''')
+                self.assertContains(rsp, 'dir="ltr"')
             elif language_code == "ar":
-                self.assertContains(rsp, '''dir="rtl"''')
+                self.assertContains(rsp, 'dir="rtl"')
 
     def test_view_license_plain_text(self):
         for language_code in ["es", "ar", DEFAULT_LANGUAGE_CODE]:
@@ -390,6 +390,16 @@ class LicenseDeedViewTest(LicensesTestsMixin, TestCase):
             license__version="3.0",
             license__jurisdiction_code="es",
             language_code="es",
+        )
+        url = lc.deed_url
+        rsp = self.client.get(url)
+        self.assertEqual(200, rsp.status_code)
+
+    def test_license_deed_view_cc0(self):
+        lc = LegalCodeFactory(
+            license__license_code="CC0",
+            license__version="1.0",
+            language_code="en",
         )
         url = lc.deed_url
         rsp = self.client.get(url)

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -492,6 +492,9 @@ class BranchStatusViewTest(TestCase):
                         "last_commit": None,
                     }
                     r = self.client.get(url)
+                    # Call a second time to test cache and fully exercise
+                    # branch_status()
+                    self.client.get(url)
         mock_helper.assert_called_with(mock.ANY, self.translation_branch)
         self.assertTemplateUsed(r, "licenses/branch_status.html")
         context = r.context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-# Force exclude is used as pre-comit feeds individual file names based on
+# Force exclude is used as pre-commit feeds individual file names based on
 # filters
 force-exclude = '''
 (
@@ -31,6 +31,8 @@ source = [
 ]
 
 [tool.coverage.report]
+fail_under = 98.00
+precision = 2
 show_missing = true
 skip_covered = true
 
@@ -52,4 +54,4 @@ profile = 'black'
 
 
 # [tool.pre-commit]
-# config: .pre-commit-config.yaml
+#   config: .pre-commit-config.yaml


### PR DESCRIPTION
## Description
- Reduce test noise
- Increase test coverage (added 7 tests)
- Move coverage configuration from command line to configuration file
- Update python dependencies

## Technical details

### Before PR
Old coverage test output:
```
Using existing test database for alias 'default'...
System check identified no issues (0 silenced).
............On branch otherbranch
nothing to commit, working tree clean
...git: 'TestInvalidCommand' is not a git command. See 'git --help'.
......................................................................................................
----------------------------------------------------------------------
Ran 117 tests in 3.491s

OK
Preserving test database for alias 'default'...
```
Old coverage report output:
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
i18n/utils.py              72      1      8      1    97.50%   126
licenses/git_utils.py      81      5     36      3    91.45%   62->exit, 97-106, 116->118, 132->137
licenses/models.py        269      1     74      1    99.42%   639
licenses/transifex.py     201      2     42      3    97.94%   47, 99, 252->exit, 285->293
licenses/views.py          90      1     22      2    97.32%   195, 283->292
----------------------------------------------------------------------
TOTAL                    1008     10    292     10    98.31%
```

### After PR
New coverage test output:
```
Using existing test database for alias 'default'...
System check identified no issues (0 silenced).
............................................................................................................................
----------------------------------------------------------------------
Ran 124 tests in 4.002s

OK
Preserving test database for alias 'default'...
```
New coverage report output:
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
i18n/utils.py              72      1      8      1    97.50%   126
licenses/git_utils.py      83      0     36      3    97.48%   70->exit, 124->126, 140->145
licenses/transifex.py     201      0     42      1    99.59%   285->293
----------------------------------------------------------------------
TOTAL                    1010      1    292      5    99.54%
```

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
