### PR TITLE
add default input_directory to load_html_files Django admin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use the following instructions to start the project with Docker compose.
         ```
    7. Load legacy HTML in the database
         ```shell
-        docker-compose run app ./manage.py load_html_files ../cc-licenses-data/legacy/legalcode
+        docker-compose run app ./manage.py load_html_files
         ```
 2. Run the containers
     ```shell
@@ -260,13 +260,14 @@ to parse BY\* 4.0 HTML files, another for CC0, another for BY\* 3.0 unported
 files, and another for BY\* 3.0 ported. We would expect to add more such
 methods for other license flavors.
 
-Each parsing method uses BeautifulSoup4 to parse the HTML text into a tree
-representing the structure of the HTML, and picks out the part of the page that
-contains the license (as opposed to navigation, styling, and boilerplate text
-that occurs on many pages). Then it uses tag id's and classes and the structure
-of the HTML to pick out the text for each part of the license (generally a
-translatable phrase or paragraph) and organize it into translation files, or
-for the ported 3.0 licenses, just pretty-prints the HTML and saves it as-is.
+Each parsing method uses [BeautifulSoup4][bs4] to parse the HTML text into a
+tree representing the structure of the HTML, and picks out the part of the page
+that contains the license (as opposed to navigation, styling, and boilerplate
+text that occurs on many pages). Then it uses tag id's and classes and the
+structure of the HTML to pick out the text for each part of the license
+(generally a translatable phrase or paragraph) and organize it into translation
+files, or for the ported 3.0 licenses, just pretty-prints the HTML and saves it
+as-is.
 
 The BY\* 4.0 licenses are the most straightforward. The text is the same from
 one license to the next (e.g. BY-NC, BY-SA) except where the actual license
@@ -308,6 +309,8 @@ inserts whatever HTML we've saved into the page.
 The older version licenses have not yet been looked at. Hopefully we can model
 importing those licenses on how we've done the 3.0 licenses.
 
+[bs4]: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
+
 
 #### Import Process
 
@@ -332,7 +335,7 @@ command line.
     ```
 4. Load legacy HTML in the database
     ```shell
-    docker-compose run app ./manage.py load_html_files ../cc-licenses-data/legacy/legalcode
+    docker-compose run app ./manage.py load_html_files
     ```
 
 [repodata]:https://github.com/creativecommons/cc-licenses-data
@@ -430,15 +433,17 @@ For each domain, there's a file for each translation. The files are all named
 language.
 
 We have the following structure in our translation data repo:
-
-    legalcode/
-       <language>/
-           LC_MESSAGES/
-                 by_4.0.mo
-                 by_4.0.po
-                 by-nc_4.0.mo
-                 by-nc_4.0.po
-                 ...
+```
+legalcode/
+├── <language>
+│   └── LC_MESSAGES
+│       ├── by-nc-nd_40.mo
+│       ├── by-nc-nd_40.po
+│       ├── by-nc-sa_40.mo
+│       ...
+│       └── by_40.po
+...
+```
 
 The language code used in the path to the files is *not* necessarily the same
 as what we're using to identify the licenses in the site URLs.  That's because
@@ -451,10 +456,7 @@ For example, the translated files for
 that translation.
 
 The `.po` files are initially created from the existing HTML license files by
-running `docker-compose run app ./manage.py load_html_files <path to
-legacy/legalcode>`, where `<path to legacy/legalcode>` is a local path to
-[creativecommons/cc-licenses-data][repodata]:
-[`legacy/legalcode`][legacylegalcode] (see also above).
+running `docker-compose run app ./manage.py load_html_files`.
 
 After this is done and merged to the main branch, it should not be done again.
 Instead, edit the HTML license template files to change the English text, and

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -1,12 +1,13 @@
 # Standard library
 import os
+import socket
 import sys
 from argparse import ArgumentParser
 
 # Third-party
 from bs4 import BeautifulSoup, Tag
 from django.conf import settings
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
 from polib import POEntry, POFile
 
 # First-party/Local
@@ -43,7 +44,14 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser: ArgumentParser):
-        parser.add_argument("input_directory")
+        default_input_dir = os.path.abspath(
+            os.path.join(settings.LEGACY_DIR, "legalcode")
+        )
+        parser.add_argument(
+            "input_directory",
+            nargs="?",
+            default=default_input_dir,
+        )
         parser.add_argument(
             "--versions",
             help="comma-separated license versions to include, e.g."
@@ -51,8 +59,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--languages",
-            help="comma-separated language codes to include, e.g. 'fr,ar' "
-            "using the codes from the CC site URLs (which sometimes differ"
+            help="comma-separated language codes to include, e.g. 'fr,ar'"
+            " using the codes from the CC site URLs (which sometimes differ"
             " from Django's. English is unconditionally included for technical"
             " reasons).",
             # We need to import English so we can figure out what the message
@@ -66,6 +74,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, input_directory, **options):
+        hostname = socket.gethostname()
+        if not os.path.isdir(input_directory):
+            raise CommandError(f"invalid input_directory: {input_directory}")
         if options["versions"]:
             versions_to_include = options["versions"].split(",")
         else:
@@ -92,8 +103,9 @@ class Command(BaseCommand):
                 and f.endswith(".html")
             ]
         )
+        self.stdout.write(f"\n{hostname}:{input_directory}")
         for filename in html_filenames:
-            # print(filename)
+            self.stdout.write(f"    {filename}")
             metadata = parse_legalcode_filename(filename)
 
             basename = os.path.splitext(filename)[0]

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -47,10 +47,15 @@ class Command(BaseCommand):
         default_input_dir = os.path.abspath(
             os.path.join(settings.LEGACY_DIR, "legalcode")
         )
+        relative_input_dir = os.path.relpath(
+            default_input_dir, start=os.path.abspath(settings.ROOT_DIR)
+        )
         parser.add_argument(
             "input_directory",
             nargs="?",
             default=default_input_dir,
+            help="directory containing legalcode legacy HTML files (if"
+            f" ommitted, the default is: {relative_input_dir})",
         )
         parser.add_argument(
             "--versions",


### PR DESCRIPTION
## Description
- `load_html_files` Django admin command
  - add default `input_directory`
  - add an error if the `input_directory` is not a directory
  - print source directory and each file as it is loaded

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
