### PR TITLE
remove "xu" and supporting symlinks from unported publish path

### DIFF
--- a/licenses/management/commands/publish.py
+++ b/licenses/management/commands/publish.py
@@ -150,12 +150,13 @@ class Command(BaseCommand):
             else:
                 continue
             relative_name = os.path.join(*name.split("_"), "rdf")
+            # "xu" is a "user assigned code" meaning "unported"
+            # See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements.  # noqa: E501
+            relative_name = relative_name.replace("xu/", "")
             dest_file = os.path.join(output_dir, relative_name)
             os.makedirs(os.path.dirname(dest_file), exist_ok=True)
             copyfile(os.path.join(licenses_rdf_dir, rdf), dest_file)
             self.stdout.write(f"    {relative_name}")
-            if relative_name.endswith("xu/rdf"):
-                relative_symlink(output_dir, relative_name, "../rdf")
 
     def run_copy_meta_rdfs(self):
         hostname = socket.gethostname()
@@ -224,8 +225,6 @@ class Command(BaseCommand):
             else:
                 context = "publicdomain"
             name = text[:-4]
-            if "3.0" in text:
-                name = f"{name}_xu"
             relative_name = os.path.join(
                 context,
                 *name.split("_"),
@@ -235,8 +234,6 @@ class Command(BaseCommand):
             os.makedirs(os.path.dirname(dest_file), exist_ok=True)
             copyfile(os.path.join(plaintext_dir, text), dest_file)
             self.stdout.write(f"    {relative_name}")
-            if relative_name.endswith("xu/legalcode.txt"):
-                relative_symlink(output_dir, relative_name, "../legalcode.txt")
 
     def distill_and_copy(self):
         self.run_clean_output_dir()

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -369,19 +369,21 @@ class LegalCodeModelTest(TestCase):
 
     def test_get_deed_or_license_path_by3(self):
         """
-        3.0 formula:
-        /licenses/VERSION/JURISDICTION/LICENSE_deed_LANGAUGE.html
-        /licenses/VERSION/JURISDICTION/LICENSE_legalcode_LANGAUGE.html
+        3.0 unported
+            Formula
+                CATEGORY/UNIT/VERSION/JURISDICTION/DOCUMENT.LANG.html
+            Examples
+                licenses/by/3.0/deed.en.html
+                licenses/by/3.0/legalcode.en.html
 
-        3.0 examples:
-        /licenses/3.0/xu/by_deed_en.html
-        /licenses/3.0/xu/by_legalcode_en.html
-        /licenses/3.0/am/by_deed_hy.html
-        /licenses/3.0/am/by_legalcode_hy.html
-        /licenses/3.0/rs/by_deed_rs-Cyrl.html
-        /licenses/3.0/rs/by_legalcode_rs-Cyrl.html
-        For jurisdiction, I used "xu" to mean "unported".
-        See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements.  # noqa: E501
+        3.0 ported
+            Formula
+                CATEGORY/UNIT/VERSION/JURISDICTION/DOCUMENT.LANG.html
+            Examples
+                licenses/by/3.0/ca/deed.en.html
+                licenses/by/3.0/ca/legalcode.en.html
+                licenses/by-sa/3.0/ca/deed.fr.html
+                licenses/by-sa/3.0/ca/legalcode.fr.html
         """
         # Unported
         self._test_get_deed_or_license_path(
@@ -392,20 +394,10 @@ class LegalCodeModelTest(TestCase):
                     "by",
                     "",
                     "en",
-                    "licenses/by/3.0/xu/deed.en.html",
-                    [
-                        "deed.html",
-                        "index.html",
-                        "../licenses/by/3.0/xu/deed.en.html",
-                        "../deed.html",
-                        "../index.html",
-                    ],
-                    "licenses/by/3.0/xu/legalcode.en.html",
-                    [
-                        "legalcode.html",
-                        "../licenses/by/3.0/xu/legalcode.en.html",
-                        "../legalcode.html",
-                    ],
+                    "licenses/by/3.0/deed.en.html",
+                    ["deed.html", "index.html"],
+                    "licenses/by/3.0/legalcode.en.html",
+                    ["legalcode.html"],
                 ),
             ]
         )


### PR DESCRIPTION
## Description
Remove "xu" and supporting symlinks from unported publish path.

The first update I made to publishing paths had jurisdictions for all 3.0 and earlier licenses ("xu" is a "user assigned code" meaning "unported"). This PR brings the published paths in line with current production paths. While conceptually, treating all 3.0 and earlier licenses the same (having a jurisdiction code), the code is actually simpler without the "xu" jurisdiction since the data model includes jurisdiction (with None values) and the publishing path should not have "xu".

Also see [User-assigned code elements - ISO 3166-1 alpha-2 - Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
