### PR TITLE
Improve views tests

### DIFF
--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -20,6 +20,7 @@ from licenses.views import (
     DEED_TEMPLATE_MAPPING,
     NUM_COMMITS,
     branch_status_helper,
+    get_category_and_category_title,
 )
 
 
@@ -340,6 +341,34 @@ class ViewLicenseTest(TestCase):
     #        self.assertContains(rsp, 'lang="de"')
     #        self.assertEqual(lc, context["legalcode"])
 
+    def test_get_category_and_category_title_category_license(self):
+        category, category_title = get_category_and_category_title(
+            category=None,
+            license=None,
+        )
+        self.assertEqual(category, "licenses")
+        self.assertEqual(category_title, "Licenses")
+
+        license = LicenseFactory(
+            category="licenses",
+            canonical_url="https://creativecommons.org/licenses/by/4.0/",
+            version="4.0",
+        )
+        category, category_title = get_category_and_category_title(
+            category=None,
+            license=license,
+        )
+        self.assertEqual(category, "licenses")
+        self.assertEqual(category_title, "Licenses")
+
+    def test_get_category_and_category_title_category_publicdomain(self):
+        category, category_title = get_category_and_category_title(
+            category="publicdomain",
+            license=None,
+        )
+        self.assertEqual(category, "publicdomain")
+        self.assertEqual(category_title, "Public Domain")
+
     def test_view_license_identifying_jurisdiction_default_language(self):
         language_code = "de"
         lc = LegalCodeFactory(
@@ -569,7 +598,7 @@ class LicenseDeedViewTest(LicensesTestsMixin, TestCase):
     #     self.assertEqual("fr", context["target_lang"])
 
 
-class BranchStatusViewTest(TestCase):
+class ViewBranchStatusTest(TestCase):
     def setUp(self):
         self.translation_branch = TranslationBranchFactory(
             language_code="fr",
@@ -723,8 +752,8 @@ class BranchStatusViewTest(TestCase):
         )
 
 
-class TranslationStatusViewTest(TestCase):
-    def test_translation_status_view(self):
+class ViewTranslationStatusTest(TestCase):
+    def test_view_translation_status(self):
         TranslationBranchFactory()
         TranslationBranchFactory()
         TranslationBranchFactory()
@@ -737,7 +766,7 @@ class TranslationStatusViewTest(TestCase):
         self.assertEqual(3, len(context["branches"]))
 
 
-class MetadataViewTest(TestCase):
+class ViewMetadataTest(TestCase):
     def test_view_metadata(self):
         LicenseFactory()
         with mock.patch.object(License, "get_metadata") as mock_get_metadata:

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -21,7 +21,7 @@ from licenses.views import (
     NUM_COMMITS,
     branch_status_helper,
     get_category_and_category_title,
-    normalize_path_and_lang
+    normalize_path_and_lang,
 )
 
 

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -787,3 +787,11 @@ class ViewMetadataTest(TestCase):
         self.assertEqual(200, rsp.status_code)
         mock_get_metadata.assert_called_with()
         self.assertEqual(b"- foo: bar\n", rsp.content)
+
+
+class ViewPageNotFoundTest(TestCase):
+    def test_view_page_not_found(self):
+        url = "/does/not/exist"
+        rsp = self.client.get(url)
+        self.assertTemplateUsed("404.html")
+        self.assertEqual(rsp.status_code, 404)

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -21,6 +21,7 @@ from licenses.views import (
     NUM_COMMITS,
     branch_status_helper,
     get_category_and_category_title,
+    normalize_path_and_lang
 )
 
 
@@ -368,6 +369,17 @@ class ViewLicenseTest(TestCase):
         )
         self.assertEqual(category, "publicdomain")
         self.assertEqual(category_title, "Public Domain")
+
+    def test_normalize_path_and_lang(self):
+        request_path = "/licenses/by/3.0/de/legalcode"
+        jurisdiction = "de"
+        norm_request_path, norm_language_code = normalize_path_and_lang(
+            request_path,
+            jurisdiction,
+            language_code=None,
+        )
+        self.assertEqual(norm_request_path, f"{request_path}.de")
+        self.assertEqual(norm_language_code, "de")
 
     def test_view_license_identifying_jurisdiction_default_language(self):
         language_code = "de"

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -400,4 +400,5 @@ def view_page_not_found(request, exception, template_name="404.html"):
             "category": "dev",
             "category_title": "Dev",
         },
+        status=404,
     )

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -52,7 +52,7 @@ def get_category_and_category_title(category=None, license=None):
         if license:
             category = license.category
         else:
-            category = "license"
+            category = "licenses"
     # category_title
     if category == "publicdomain":
         category_title = "Public Domain"

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -180,16 +180,22 @@ def view_license(
     request.path, language_code = normalize_path_and_lang(
         request.path, jurisdiction, language_code
     )
-    if is_plain_text:
-        legalcode = get_object_or_404(
-            LegalCode,
-            plain_text_url=request.path,
-        )
-    else:
-        legalcode = get_object_or_404(
-            LegalCode,
-            license_url=request.path,
-        )
+    # Plaintext disabled
+    # if is_plain_text:
+    #     legalcode = get_object_or_404(
+    #         LegalCode,
+    #         plain_text_url=request.path,
+    #     )
+    # else:
+    #     legalcode = get_object_or_404(
+    #         LegalCode,
+    #         license_url=request.path,
+    #     )
+    legalcode = get_object_or_404(
+        LegalCode,
+        license_url=request.path,
+    )
+
     license = legalcode.license
     category, category_title = get_category_and_category_title(
         category,


### PR DESCRIPTION
## Fixes
Fixes #138

## Description
- `licenses/views.py`:
  1. Fix issues
     - add `status=404` to output of `view_page_not_found` function
     - correct default category (`licenses` instead of ~~`license`~~)
     - disable plaintext logic in `view_license` function
- `licenses/tests/test_views.py`:
  1. Fix issues
     - update class and function names to match previous `licenses/views.py` function renames
  2. complete text coverage (`licenses/views.py` is now one of the fifteen files skipped):
        ```
        Name                    Stmts   Miss Branch BrPart     Cover   Missing
        ----------------------------------------------------------------------
        i18n/utils.py              72      1      8      1    97.50%   126
        licenses/git_utils.py      83      0     36      3    97.48%   70->exit, 124->126, 140->145
        licenses/models.py        241      0     50      1    99.66%   534->542
        licenses/transifex.py     201      0     42      1    99.59%   285->293
        licenses/utils.py         172      3     78      2    98.00%   60, 154-155
        ----------------------------------------------------------------------
        TOTAL                    1000      4    282      8    99.06%
        
        15 files skipped due to complete coverage.
        ```


## Related documentation
- [render | Django shortcut functions | Django documentation | Django](https://docs.djangoproject.com/en/2.2/topics/http/shortcuts/#render)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
