### PR TITLE
Improve i18n test coverage

### DIFF
--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 
 # First-party/Local
 from i18n.utils import (
+    active_translation,
     get_translation_object,
     save_content_as_pofile_and_mofile,
 )
@@ -39,6 +40,24 @@ class TranslationTest(TestCase):
         )
         mock_trans.assert_called_with("code")
         self.assertEqual(translation_object, result)
+
+    def test_active_translation(self):
+        # Third-party
+        from django.utils.translation.trans_real import _active
+
+        translation_object = getattr(_active, "value", None)
+        with active_translation(translation_object):
+            self.assertEqual(
+                getattr(_active, "value", None),
+                translation_object,
+            )
+        del _active.value
+        self.assertEqual(getattr(_active, "value", None), None)
+        with active_translation(translation_object):
+            self.assertEqual(
+                getattr(_active, "value", None),
+                translation_object,
+            )
 
 
 class PofileTest(TestCase):


### PR DESCRIPTION
## Fixes
Fixes #140

## Description
Complete text coverage (`i18n/utils.py` is now one of the sixteen files skipped):
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      0     36      3    97.48%   70->exit, 124->126, 140->145
licenses/models.py        241      0     50      1    99.66%   534->542
licenses/transifex.py     201      0     42      1    99.59%   285->293
licenses/utils.py         172      3     78      2    98.00%   60, 154-155
----------------------------------------------------------------------
TOTAL                    1000      3    282      7    99.22%

16 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
