### PR TITLE
Retired notice

### DIFF
--- a/cc_licenses/templates/includes/deed_unimplemented.html
+++ b/cc_licenses/templates/includes/deed_unimplemented.html
@@ -4,6 +4,6 @@
 
   <h3 class="b-header has-text-black padding-bottom-big padding-top-normal" style="font-weight: bold;">Error</h3>
 
-  <p class="has-text-black body-big padding-bottom-normal"><strong>Unimplemented</strong> &mdash; this legal tool does not have a valid deed template. Please report this issue: <a href="https://github.com/creativecommons/cc-licenses/issues">Issues · creativecommons/cc-licenses</a>.</p>
+  <p class="has-text-black body-big padding-bottom-normal"><strong>{% trans "Unimplemented" %}</strong> &mdash; {% blocktrans %}this legal tool does not have a valid template. Please report this issue:{% endblocktrans %} <a href="https://github.com/creativecommons/cc-licenses/issues">Issues · creativecommons/cc-licenses</a>.</p>
 </div>
 {# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}

--- a/cc_licenses/templates/includes/deprecated.html
+++ b/cc_licenses/templates/includes/deprecated.html
@@ -1,0 +1,12 @@
+{% load bidi i18n %}
+
+{# refactor this code and use "with" template tag in licenses_detail.html to pass header and text to these templates #}
+{# if this content will be modified through the django admin in the future #}
+
+<div id="disclaimer-info-section" class="padding-bigger has-background-info-light" >
+  <h4 class="padding-bottom-normal is-vcentered b-header"><i class="info icon padding-{% end %}-normal"></i>{% trans "Disclaimer" %}</h4>
+  <p class="has-text-black padding-{% start %}-big">
+  {{ license.deprecated_on }}: {% blocktrans %}Creative Commons has <a href="http://creativecommons.org/retiredlicenses">retired this legal tool</a> and does not recommend that it be applied to works.{% endblocktrans %}
+  </p>
+</div>
+{# vim: ft=jinja.html ts=2 sw=2 sts=2 sr et #}

--- a/cc_licenses/templates/includes/menu-sidebar.html
+++ b/cc_licenses/templates/includes/menu-sidebar.html
@@ -2,11 +2,6 @@
 
 <div class="column is-one-quarter sidebar-container">
   <aside class="menu sidebar-menu">
-    {# Non-Menu for crude html #}
-    {% if legalcode.html %}
-      <a class="link has-text-black is-block padding-bottom-normal" href="#legal-code-body">{{ legalcode.title }}</a>
-    {% endif %}
-
     {# Menu #}
     <ul class="menu-list" >
       <li>

--- a/licenses/templates/deed.html
+++ b/licenses/templates/deed.html
@@ -18,8 +18,11 @@
 
 {% block content %}
   <div class="container">
+    {% if license.deprecated_on %}
+      {% include 'includes/deprecated.html' %}
+    {% endif %}
     {% include body_template %}
-    {% if license.version == "4.0" %}
+    {% if category == "licenses" and license.version == "4.0" %}
       {% include 'includes/disclaimer_40.html' %}
     {% elif license.unit == "CC0" %}
       {% include 'includes/disclaimer_cc0.html' %}

--- a/licenses/templates/legalcode_page.html
+++ b/licenses/templates/legalcode_page.html
@@ -28,26 +28,32 @@
 
 {% block content %}
   <div class="columns">
-    {% include 'includes/menu-sidebar.html' %}
+    {% if not legalcode.html %}
+      {% include 'includes/menu-sidebar.html' %}
+    {% endif %}
     <div class="column">
       {% include 'includes/licenses_header.html' %}  {#  Title and icons #}
+      {% if license.deprecated_on %}
+        {% include 'includes/deprecated.html' %} {# Retired legal tool notice #}
+      {% endif %}
       {% if not legalcode.html %}
         {% include 'includes/about_cc_and_license.html' %}  {#  CC IS NOT A LAW FIRM #}
         {% include 'includes/use_of_licenses.html' %}  {# Considerations... #}
-      {% endif %}
-      {% if license.category == "publicdomain" and license.unit == "CC0" %}
-        {% include 'includes/legalcode_cc0.html' %}  {# <<< THE ACTUAL CC0 LICENSE TEXT #}
-      {% elif license.category == "licenses" and license.version == "4.0" %}
-        {% include 'includes/legalcode_licenses_4.0.html' %}  {# <<< THE ACTUAL 4.0 LICENSE TEXT #}
-      {% elif license.category == "licenses" and license.version == "3.0" and not license.jurisdiction_code %}
-        {% include 'includes/legalcode_licenses_3.0_unported.html' %}  {# <<< THE ACTUAL 3.0 unported LICENSE TEXT #}
+        {% if license.category == "publicdomain" and license.unit == "CC0" %}
+          {% include 'includes/legalcode_cc0.html' %}  {# <<< THE ACTUAL CC0 LICENSE TEXT #}
+        {% elif license.category == "licenses" and license.version == "4.0" %}
+          {% include 'includes/legalcode_licenses_4.0.html' %}  {# <<< THE ACTUAL 4.0 LICENSE TEXT #}
+        {% elif license.category == "licenses" and license.version == "3.0" and not license.jurisdiction_code %}
+          {% include 'includes/legalcode_licenses_3.0_unported.html' %}  {# <<< THE ACTUAL 3.0 unported LICENSE TEXT #}
+        {% else %}
+          <div id="legal-code-body" class="padding-larger margin-top-bigger has-text-black    ">
+            <p class="has-text-black body-big padding-bottom-normal"><strong>{% trans "Unimplemented" %}</strong> &mdash; {% blocktrans %}this legal tool does not have a valid template. Please report this issue:{% endblocktrans %} <a href="https://github.com/creativecommons/cc-licenses/issues">Issues · creativecommons/cc-licenses</a>.</p>
+          </div>
+        {% endif %}
+        {% include 'includes/about_cc.html' %}
+        {#{% include 'includes/view_legal_code_link_plain_text.html' %}#}
       {% else %}
         {% include "includes/legalcode_crude_html.html" %}
-      {% endif %}
-
-      {#{% include 'includes/view_legal_code_link_plain_text.html' %}#}
-      {% if not legalcode.html %}
-        {% include 'includes/about_cc.html' %}
       {% endif %}
       {% include 'includes/related_links.html' %}
     </div>

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -384,12 +384,13 @@ class ViewLicenseTest(TestCase):
     def test_view_license_identifying_jurisdiction_default_language(self):
         language_code = "de"
         lc = LegalCodeFactory(
+            html="crude",
+            language_code=language_code,
             license__category="licenses",
             license__canonical_url="https://creativecommons.org"
             "/licenses/by/3.0/de/",
             license__version="3.0",
             license__jurisdiction_code="de",
-            language_code=language_code,
         )
         url = lc.license_url
         rsp = self.client.get(url)


### PR DESCRIPTION
## Description
- Add retired legal tool notice
  - unlike the current/legacy ccEngine, the notice is displayed above *both* the deed and the legalcode
- Improve display (and logic) for crude HTML legalcode (legalcode that is loaded simply instead of being fully imported)
  - An essentially empty menu (it had only the title) is no longer displayed for cude HTML legalcode 

## Documentation
- [Templates | Django documentation | Django](https://docs.djangoproject.com/en/2.2/ref/templates/)

## Screenshots
<img width="1074" alt="samplinglegalcode" src="https://user-images.githubusercontent.com/691322/123844899-6f761300-d8c8-11eb-9a75-3612135f028d.png">

<img width="1070" alt="Screen Shot 2021-06-29 at 10 53 09" src="https://user-images.githubusercontent.com/691322/123844908-73a23080-d8c8-11eb-8888-5527af84000a.png">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
