### PR TITLE
Disable plaintext generation

### DIFF
--- a/licenses/admin.py
+++ b/licenses/admin.py
@@ -32,7 +32,7 @@ class LegalCodeAdmin(admin.ModelAdmin):
         "language_code",
         "legal_code_url",
         "deed_url",
-        "plain_text_url",
+        # "plain_text_url",  # NOTE: plaintext functionality disabled
         "html_file",
         "html",
     ]

--- a/licenses/models.py
+++ b/licenses/models.py
@@ -222,7 +222,6 @@ class LegalCode(models.Model):
         return f"LegalCode<{self.language_code}, {self.license}>"
 
     def save(self, *args, **kwargs):
-        unit = self.license.unit
         self.deed_url = build_path(
             self.license.canonical_url,
             "deed",
@@ -233,15 +232,17 @@ class LegalCode(models.Model):
             "legalcode",
             self.language_code,
         )
-        if (
-            (unit in UNITS_LICENSES and float(self.license.version) > 2.5)
-            or unit == "zero"
-        ) and self.language_code == "en":
-            self.plain_text_url = build_path(
-                self.license.canonical_url,
-                "legalcode.txt",
-                self.language_code,
-            )
+        # NOTE: plaintext functionality disabled
+        # unit = self.license.unit
+        # if (
+        #     (unit in UNITS_LICENSES and float(self.license.version) > 2.5)
+        #     or unit == "zero"
+        # ) and self.language_code == "en":
+        #     self.plain_text_url = build_path(
+        #         self.license.canonical_url,
+        #         "legalcode.txt",
+        #         self.language_code,
+        #     )
         super().save(*args, **kwargs)
 
     def _get_save_path(self):

--- a/licenses/templates/legalcode.html
+++ b/licenses/templates/legalcode.html
@@ -51,7 +51,8 @@
           </div>
         {% endif %}
         {% include 'includes/about_cc.html' %}
-        {#{% include 'includes/view_legal_code_link_plain_text.html' %}#}
+        {# NOTE: plaintext functionality disabled
+        {# {% include 'includes/view_legal_code_link_plain_text.html' %} #}
       {% else %}
         {% include "includes/legalcode_crude_html.html" %}
       {% endif %}

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -177,31 +177,32 @@ class LegalCodeModelTest(TestCase):
                     ).translation_filename(),
                 )
 
-    def test_plain_text_url(self):
-        lc0 = LegalCodeFactory(
-            license__unit="by",
-            license__version="4.0",
-            license__jurisdiction_code="",
-            language_code="en",
-        )
-        lc1 = LegalCodeFactory(
-            license__unit="by",
-            license__version="4.0",
-            license__jurisdiction_code="",
-            language_code="fr",
-        )
-        lc2 = LegalCodeFactory(
-            license__unit="by",
-            license__version="4.0",
-            license__jurisdiction_code="",
-            language_code="ar",
-        )
-        self.assertEqual(
-            lc0.plain_text_url,
-            f"{lc0.legal_code_url.replace('legalcode.en', 'legalcode.txt')}",
-        )
-        self.assertEqual(lc1.plain_text_url, "")
-        self.assertEqual(lc2.plain_text_url, "")
+    # NOTE: plaintext functionality disabled
+    # def test_plain_text_url(self):
+    #     lc0 = LegalCodeFactory(
+    #         license__unit="by",
+    #         license__version="4.0",
+    #         license__jurisdiction_code="",
+    #         language_code="en",
+    #     )
+    #     lc1 = LegalCodeFactory(
+    #         license__unit="by",
+    #         license__version="4.0",
+    #         license__jurisdiction_code="",
+    #         language_code="fr",
+    #     )
+    #     lc2 = LegalCodeFactory(
+    #         license__unit="by",
+    #         license__version="4.0",
+    #         license__jurisdiction_code="",
+    #         language_code="ar",
+    #     )
+    #     self.assertEqual(
+    #         lc0.plain_text_url,
+    #         f"{lc0.legal_code_url.replace('legalcode.en', 'legalcode.txt')}",
+    #     )
+    #     self.assertEqual(lc1.plain_text_url, "")
+    #     self.assertEqual(lc2.plain_text_url, "")
 
     def test_get_pofile(self):
         legal_code = LegalCodeFactory()

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -424,38 +424,38 @@ class ViewLicenseTest(TestCase):
             elif language_code == "ar":
                 self.assertContains(rsp, 'dir="rtl"')
 
-# Disabled pending plaintext file generation
-#
-#    def test_view_legal_code_plain_text(self):
-#        license = LicenseFactory(
-#            canonical_url="https://creativecommons.org/licenses/by/4.0/",
-#            version="4.0",
-#        )
-#        for language_code in [DEFAULT_LANGUAGE_CODE]:
-#            lc = LegalCodeFactory(
-#                license=license,
-#                language_code=language_code,
-#            )
-#            url = lc.plain_text_url
-#            rsp = self.client.get(url)
-#            self.assertEqual(
-#                'text/plain; charset="utf-8"', rsp._headers["content-type"][1]
-#            )
-#            self.assertEqual(200, rsp.status_code)
-#            self.assertGreater(len(rsp.content.decode()), 0)
-#        lc = LegalCodeFactory(
-#            license__version="3.0",
-#            language_code="fr",
-#            license__unit="by",
-#            license__jurisdiction_code="ch",
-#        )
-#        url = lc.plain_text_url
-#        rsp = self.client.get(url)
-#        self.assertEqual(
-#            'text/plain; charset="utf-8"', rsp._headers["content-type"][1]
-#        )
-#        self.assertEqual(200, rsp.status_code)
-#        self.assertGreater(len(rsp.content.decode()), 0)
+    # NOTE: plaintext functionality disabled
+    # def test_view_legal_code_plain_text(self):
+    #     license = LicenseFactory(
+    #         canonical_url="https://creativecommons.org/licenses/by/4.0/",
+    #         version="4.0",
+    #     )
+    #     for language_code in [DEFAULT_LANGUAGE_CODE]:
+    #         lc = LegalCodeFactory(
+    #             license=license,
+    #             language_code=language_code,
+    #         )
+    #         url = lc.plain_text_url
+    #         rsp = self.client.get(url)
+    #         self.assertEqual(
+    #             'text/plain; charset="utf-8"',
+    #             rsp._headers["content-type"][1]
+    #         )
+    #         self.assertEqual(200, rsp.status_code)
+    #         self.assertGreater(len(rsp.content.decode()), 0)
+    #     lc = LegalCodeFactory(
+    #         license__version="3.0",
+    #         language_code="fr",
+    #         license__unit="by",
+    #         license__jurisdiction_code="ch",
+    #     )
+    #     url = lc.plain_text_url
+    #     rsp = self.client.get(url)
+    #     self.assertEqual(
+    #         'text/plain; charset="utf-8"', rsp._headers["content-type"][1]
+    #     )
+    #     self.assertEqual(200, rsp.status_code)
+    #     self.assertGreater(len(rsp.content.decode()), 0)
 
 
 class LicenseDeedViewTest(LicensesTestsMixin, TestCase):

--- a/licenses/urls.py
+++ b/licenses/urls.py
@@ -232,6 +232,7 @@ urlpatterns = [
         kwargs=dict(jurisdiction=""),
         name="view_legal_code_unported",
     ),
+    # NOTE: plaintext functionality disabled
     # # Plaintext Legalcode: no Jurisdiction (int/unported), no language_code
     # path(
     #     "<category:category>/<unit:unit>/<version:version>/legalcode.txt",
@@ -239,5 +240,4 @@ urlpatterns = [
     #     kwargs=dict(jurisdiction="", is_plain_text=True),
     #     name="view_legal_code_unported",
     # ),
-    #
 ]

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -245,7 +245,7 @@ def view_legal_code(
         request.path, jurisdiction, language_code
     )
     path_start = os.path.dirname(request.path)
-    # Plaintext disabled
+    # NOTE: plaintext functionality disabled
     # if is_plain_text:
     #     legal_code = get_object_or_404(
     #         LegalCode,
@@ -291,6 +291,7 @@ def view_legal_code(
 
     translation = legal_code.get_translation_object()
     with active_translation(translation):
+        # NOTE: plaintext functionality disabled
         # if is_plain_text:
         #     response = HttpResponse(
         #         content_type='text/plain; charset="utf-8"'
@@ -315,7 +316,7 @@ def view_legal_code(
         #         )
         #         response.write(output.stdout)
         #         return response
-
+        #
         return render(request, **kwargs)
 
 


### PR DESCRIPTION
## Description
disable plaintext functionality
- completely disable plain text file generation (functionality was previously partially disabled)
- ensure the same comment is used throughout for easier discovery/navigation

I disabled the plaintext functionality because it is non-deterministic. The `legalcode.txt` files must not change due to tool chain (ex. pandoc) updates. The plaintext files are sometimes programmatically matched to determine repository licensing.

I did not remove the code, as I expect it may have utility in the future.

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      0     36      3    97.48%   70->exit, 124->126, 140->145
licenses/models.py        246      1     52      1    99.33%   609
licenses/transifex.py     201      0     42      1    99.59%   285->293
licenses/utils.py         167      1     78      1    99.18%   59
licenses/views.py         126      2     44      2    97.65%   210, 212
----------------------------------------------------------------------
TOTAL                    1011      4    290      8    99.08%

15 files skipped due to complete coverage.
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- `N/A` I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
