### PR TITLE
Language update

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,7 +47,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: creativecommons/cc-licenses-data
-        path: ../cc-licenses-data
 
     - name: Configure testing git identity
       run: |
@@ -70,12 +69,19 @@ jobs:
         pipenv sync --dev
 
     - name: Update Django database schema
+      env:
+        DATA_REPOSITORY_DIR: cc-licenses-data
       run: |
         pipenv run ./manage.py migrate
 
     - name: Start Django development web server
+      env:
+        DATA_REPOSITORY_DIR: cc-licenses-data
+
       run: |
         pipenv run ./manage.py runserver &>/dev/null &
 
     # https://github.com/pre-commit/action
     - uses: pre-commit/action@v2.0.0
+      env:
+        DATA_REPOSITORY_DIR: cc-licenses-data

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,6 +47,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: creativecommons/cc-licenses-data
+        path: cc-licenses-data
 
     - name: Configure testing git identity
       run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -39,7 +39,15 @@ jobs:
         sudo apt-get install -y pandoc
 
     # https://github.com/actions/checkout
-    - uses: actions/checkout@v2
+    - name: Checkout cc-licenses
+      uses: actions/checkout@v2
+
+    # https://github.com/actions/checkout
+    - name: Checkout cc-licenses-data
+      uses: actions/checkout@v2
+      with:
+        repository: creativecommons/cc-licenses-data
+        path: ../cc-licenses-data
 
     - name: Configure testing git identity
       run: |

--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -142,6 +142,12 @@ LANGUAGE_CODE = "en"  # "en" matches our default language code in Transifex
 
 # https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 # Teach Django about a few more languages
+LANG_INFO["an"] = {  # Aragonese
+    "bidi": False,
+    "code": "an",
+    "name": "Aragonese",
+    "name_local": "aragonés",
+}
 mi = Locale.parse("mi")
 LANG_INFO["mi"] = {  # Maori
     "bidi": False,
@@ -154,12 +160,6 @@ LANG_INFO["ms"] = {  # Malay
     "code": "ms",
     "name": "Malay",
     "name_local": "Bahasa Melayu",  # ??
-}
-LANG_INFO["zh-Hans"] = {
-    "fallback": ["zh-hans"],
-}
-LANG_INFO["zh-Hant"] = {
-    "fallback": ["zh-hant"],
 }
 LANG_INFO["oci"] = {  # Occitan? https://iso639-3.sil.org/code/oci
     "bidi": False,

--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -267,12 +267,9 @@ DATA_REPOSITORY_DIR = os.getenv(
 DISTILL_DIR = os.path.join(DATA_REPOSITORY_DIR, "docs")
 LEGACY_DIR = os.path.join(DATA_REPOSITORY_DIR, "legacy")
 
-# Django translations are in the translation repo directory, under "locale".
-# License translations are in the translation repo directory, under
-# "translations".
 LOCALE_PATHS = (
-    os.path.join(DATA_REPOSITORY_DIR, "locale"),
-    os.path.join(DATA_REPOSITORY_DIR, "legalcode"),
+    os.path.join(DATA_REPOSITORY_DIR, "locale"),  # Deed/UX translations
+    os.path.join(DATA_REPOSITORY_DIR, "legalcode"),  # Legal Code translations
 )
 
 TRANSIFEX = {

--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -176,7 +176,7 @@ LANG_INFO["oci"] = {  # Occitan? https://iso639-3.sil.org/code/oci
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = "America/New_York"
+TIME_ZONE = "Etc/UTC"
 
 USE_I18N = True
 

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -58,7 +58,7 @@ DEFAULT_JURISDICTION_LANGUAGES = {
     # YES https://creativecommons.org/licenses/by/3.0/ch/legalcode.de
     "ch": "de",  # ch=Switzerland, default in jurisdictions.rdf=de
     "cl": "es",
-    "cn": "zh-Hans",  # "cn" is China Mainland, language is simplified Chinese
+    "cn": "zh-hans",  # "cn" is China Mainland, language is simplified Chinese
     "co": "es",
     "cr": "es",
     "cz": "cs",
@@ -85,7 +85,7 @@ DEFAULT_JURISDICTION_LANGUAGES = {
     "hk": "en-gb",
     "hr": "hr",
     "hu": "hu",
-    "ie": "en-GB",
+    "ie": "en-gb",
     "igo": "en",
     "il": "he",
     "in": "en-gb",
@@ -197,12 +197,11 @@ JURISDICTION_NAMES = {
 LANGUAGE_CODE_REGEX_STRING = r"[a-zA-Z_-]*"
 DJANGO_LANGUAGE_CODES = {
     # CC language code: django language code
-    "en-GB": "en-gb",
-    "sr-Cyrl": "sr",
-    "sr-Latn": "sr-latn",
+    "es-es": "es",
+    "sr-cyrl": "sr",
     "zh": "zh-hans",  # Assume mainland china
-    "zh-Hans": "zh-hans",  # "zh_Hans",
-    "zh-Hant": "zh-hant",  # "zh_Hant",
+    "zh-cn": "zh-hans",
+    "zh-tw": "zh-hant",
 }
 FILENAME_LANGUAGE_CODES = {
     # CC language code: language code for path to translation files

--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -26,10 +26,16 @@ DEFAULT_LANGUAGE_CODE = "en"
 # The language codes here are CC language codes, which sometimes differ from
 # Django language codes.
 DEFAULT_JURISDICTION_LANGUAGES = {
-    # Map jurisdiction code to language code. IMPORTANT: Some of the
-    # jurisdiction codes look like language codes, but they're not necessarily
-    # related. E.g. "ar" is the language code for Arabic, but the jurisdiction
-    # code for Argentina.
+    # Map jurisdiction code to language code.
+    #
+    # IMPORTANT: language codes and jurisdictions are different:
+    # - language codes are RFC5646 language tags
+    # - jurisdictions are ISO 3166-1 alpha-2 codes
+    #
+    # For example:
+    # - "ar" is the RFC5646 language tag for Arabic
+    # - "ar" is the ISO 3166-1 alpha-2 code for Argentina
+    #
     # See the "JURISDICTION_NAMES", just below this.
     "am": "hy",  # Armenian - not in jurisdictions.rdf
     "ar": "es",

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -159,7 +159,19 @@ def cc_to_django_language_code(cc_language_code: str) -> str:
     Given a CC language code, return the language code that Django
     uses to represent that language.
     """
-    return DJANGO_LANGUAGE_CODES.get(cc_language_code, cc_language_code)
+    django_language_code = cc_language_code
+    # Normalize: lowercase
+    django_language_code = django_language_code.lower()
+    # Noarmalize: use dash
+    django_language_code = django_language_code.replace("@", "-")
+    django_language_code = django_language_code.replace("_", "-")
+    # Lookup special cases
+    django_language_code = DJANGO_LANGUAGE_CODES.get(
+        django_language_code,
+        django_language_code,
+    )
+
+    return django_language_code
 
 
 def cc_to_filename_language_code(cc_language_code: str) -> str:

--- a/licenses/apps.py
+++ b/licenses/apps.py
@@ -1,7 +1,13 @@
+# Standard library
+import os
+
 # Third-party
+import polib
 from django.apps import AppConfig
+from django.conf import settings
 
 # First-party/Local
+from i18n.utils import cc_to_django_language_code
 from licenses.git_utils import setup_to_call_git
 
 
@@ -9,6 +15,23 @@ class LicensesConfig(AppConfig):
     name = "licenses"  # required: must be the Full dotted path to the app
     label = "licenses"  # optional: app label, must be unique in Django project
     verbose_name = "Licenses"  # optional
+    LANGUAGES_TRANSLATED = []
+    locale_dir = os.path.join(settings.DATA_REPOSITORY_DIR, "locale")
+    locale_dir = os.path.abspath(os.path.realpath(locale_dir))
+    for language_code in os.listdir(locale_dir):
+        po_file = os.path.join(
+            locale_dir,
+            language_code,
+            "LC_MESSAGES",
+            "django.po",
+        )
+        if not os.path.isfile(po_file):
+            continue
+        po = polib.pofile(po_file)
+        if po.percent_translated() < 80:
+            continue
+        LANGUAGES_TRANSLATED.append(cc_to_django_language_code(language_code))
+    settings.LANGUAGES_TRANSLATED = sorted(list(set(LANGUAGES_TRANSLATED)))
 
     def ready(self):
         setup_to_call_git()

--- a/licenses/templates/dev/home.html
+++ b/licenses/templates/dev/home.html
@@ -11,6 +11,9 @@ the generation of static files.
 {% endblock %}
 
 {% block content %}
+{% trans "Deed" as deed_translated %}
+{% trans "Legal Code" as legal_code_translated %}
+
   <style>
     h2, h3, h4 {
       margin-top:1em;
@@ -62,8 +65,8 @@ the generation of static files.
                         <th>{{ legal_code_group.grouper }}</th>
                         {% for legal_code in legal_code_group.list  %}
                           <td>
-                            <a href="{{ legal_code.deed_url }}">{% trans "Deed" %}</a>{% if not legal_code.deed_only %},
-                              <a href="{{ legal_code.legal_code_url }}">{% trans "Legal Code" %}</a>
+                            <a href="{{ legal_code.deed_url }}">{{ deed_translated }}</a>{% if not legal_code.deed_only %},
+                              <a href="{{ legal_code.legal_code_url }}">{{ legal_code_translated }}</a>
                             {% endif %}
                           </td>
                         {% endfor %}
@@ -102,8 +105,8 @@ the generation of static files.
                     <th>{{ legal_code_group.grouper }}</th>
                     {% for legal_code in legal_code_group.list  %}
                       <td>
-                        <a href="{{ legal_code.deed_url }}">{% trans "Deed" %}</a>,
-                        <a href="{{ legal_code.legal_code_url }}">{% trans "Legal Code" %}</a>
+                        <a href="{{ legal_code.deed_url }}">{{ deed_translated }}</a>,
+                        <a href="{{ legal_code.legal_code_url }}">{{ legal_code_translated }}</a>
                       </td>
                     {% endfor %}
                   </tr>

--- a/licenses/tests/test_views.py
+++ b/licenses/tests/test_views.py
@@ -276,7 +276,7 @@ class LicensesTestsMixin:
             prohibits_high_income_nation_use=False,
         )
         LegalCodeFactory(
-            license=self.by_sa_30_es, language_code="es-es"
+            license=self.by_sa_30_es, language_code="es"
         )  # Default lang
 
         self.by_sa_20_es = LicenseFactory(
@@ -297,7 +297,7 @@ class LicensesTestsMixin:
             prohibits_high_income_nation_use=False,
         )
         LegalCodeFactory(
-            license=self.by_sa_20_es, language_code="es-es"
+            license=self.by_sa_20_es, language_code="es"
         )  # Default lang
 
         super().setUp()
@@ -541,17 +541,6 @@ class LicenseDeedViewTest(LicensesTestsMixin, TestCase):
         url = lc.deed_url
         rsp = self.client.get(url)
         self.assertEqual(200, rsp.status_code)
-
-    def test_license_deed_view_deed_unimplemented(self):
-        lc = LegalCodeFactory(
-            license__category="licenses",
-            license__canonical_url="https://creativecommons.org/licenses/x/0/",
-            license__unit="x",
-        )
-        url = lc.deed_url
-        rsp = self.client.get(url)
-        self.assertEqual(rsp.status_code, 200)
-        self.assertTemplateUsed(rsp, "includes/deed_body_unimplemented.html")
 
     # def test_deed_for_superseded_license(self):
     #     unit = "by-nc-sa"

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.cache import caches
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
-from django.utils.translation import get_language_info
+from django.utils import translation
 
 # First-party/Local
 from i18n import DEFAULT_LANGUAGE_CODE, JURISDICTION_NAMES
@@ -49,13 +49,84 @@ def get_category_and_category_title(category=None, license=None):
     return category, category_title
 
 
+def get_languages_and_links_for_deeds_ux(request_path, selected_language_code):
+    languages_and_links = []
+
+    for language_code in settings.LANGUAGES_TRANSLATED:
+        language_info = translation.get_language_info(language_code)
+        link = request_path.replace(
+            f".{selected_language_code}",
+            f".{language_code}",
+        )
+        languages_and_links.append(
+            {
+                "cc_language_code": language_code,
+                "name_local": language_info["name_local"],
+                "name_for_sorting": language_info["name_local"].lower(),
+                "link": link,
+                "selected": selected_language_code == language_code,
+            }
+        )
+    languages_and_links.sort(key=itemgetter("name_for_sorting"))
+    return languages_and_links
+
+
+def get_languages_and_links_for_legal_codes(
+    path_start,
+    legal_codes: Iterable[LegalCode],
+    selected_language_code: str,
+    legal_code_or_deed: str,
+):
+    """
+    legal_code_or_deed should be "deed" or "legal code", controlling which kind
+    of page we link to.
+
+    selected_language_code is a CC language code (RFC 5646 language tag)
+    """
+    languages_and_links = [
+        {
+            "cc_language_code": legal_code.language_code,
+            # name_local: name of language in its own language
+            "name_local": name_local(legal_code),
+            "name_for_sorting": name_local(legal_code).lower(),
+            "link": os.path.relpath(legal_code.deed_url, start=path_start)
+            if legal_code_or_deed == "deed"
+            else os.path.relpath(legal_code.legal_code_url, start=path_start),
+            "selected": selected_language_code == legal_code.language_code,
+        }
+        for legal_code in legal_codes
+    ]
+    languages_and_links.sort(key=itemgetter("name_for_sorting"))
+    if len(languages_and_links) < 2:
+        # Return an empty list if there are not multiple languages available
+        # (this will result in the language dropdown not being shown with a
+        # single currently active language)
+        languages_and_links = None
+    return languages_and_links
+
+
+def name_local(legal_code):
+    return translation.get_language_info(
+        cc_to_django_language_code(legal_code.language_code)
+    )["name_local"]
+
+
+def normalize_path_and_lang(request_path, jurisdiction, language_code):
+    if not language_code:
+        language_code = get_default_language_for_jurisdiction(
+            jurisdiction, DEFAULT_LANGUAGE_CODE
+        )
+    if not request_path.endswith(f".{language_code}"):
+        request_path = f"{request_path}.{language_code}"
+    return request_path, language_code
+
+
 def view_dev_home(request, category=None):
     """
     For test purposes, this displays all the available deeds and licenses in
     tables. This is not intended for public use and should not be included in
     the generation of static files.
     """
-
     # Get the list of units and languages that occur among the licenses
     # to let the template iterate over them as it likes.
     legal_code_objects = (
@@ -113,61 +184,11 @@ def view_dev_home(request, category=None):
         context={
             "category": "dev",
             "category_title": "Dev",
-            "units": sorted(UNITS_PUBLIC_DOMAIN + UNITS_LICENSES),
             "licenses": licenses,
             "publicdomain": publicdomain,
+            "units": sorted(UNITS_PUBLIC_DOMAIN + UNITS_LICENSES),
         },
     )
-
-
-def name_local(legal_code):
-    return get_language_info(
-        cc_to_django_language_code(legal_code.language_code)
-    )["name_local"]
-
-
-def get_languages_and_links_for_legal_codes(
-    path_start,
-    legal_codes: Iterable[LegalCode],
-    selected_language_code: str,
-    legal_code_or_deed: str,
-):
-    """
-    legal_code_or_deed should be "deed" or "legal code", controlling which kind
-    of page we link to.
-
-    selected_language_code is a CC language code (RFC 5646 language tag)
-    """
-    languages_and_links = [
-        {
-            "cc_language_code": legal_code.language_code,
-            # name_local: name of language in its own language
-            "name_local": name_local(legal_code),
-            "name_for_sorting": name_local(legal_code).lower(),
-            "link": os.path.relpath(legal_code.deed_url, start=path_start)
-            if legal_code_or_deed == "deed"
-            else os.path.relpath(legal_code.legal_code_url, start=path_start),
-            "selected": selected_language_code == legal_code.language_code,
-        }
-        for legal_code in legal_codes
-    ]
-    languages_and_links.sort(key=itemgetter("name_for_sorting"))
-    if len(languages_and_links) < 2:
-        # Return an empty list if there are not multiple languages available
-        # (this will result in the language dropdown not being shown with a
-        # single currently active language)
-        languages_and_links = None
-    return languages_and_links
-
-
-def normalize_path_and_lang(request_path, jurisdiction, language_code):
-    if not language_code:
-        language_code = get_default_language_for_jurisdiction(
-            jurisdiction, DEFAULT_LANGUAGE_CODE
-        )
-    if not request_path.endswith(f".{language_code}"):
-        request_path = f"{request_path}.{language_code}"
-    return request_path, language_code
 
 
 def view_deed(
@@ -182,10 +203,21 @@ def view_deed(
         request.path, jurisdiction, language_code
     )
     path_start = os.path.dirname(request.path)
+    language_default = get_default_language_for_jurisdiction(jurisdiction)
+
+    # The Legal Code translations are specific.
+    # The Deed translations are generic: all of the Deeds of a given unit share
+    # the same text. Therefore, for the purpose of displaying the Deed, we do
+    # not care about the language of the associated Legal Code.
+    default_deed_url = request.path.replace(
+        f"deed.{language_code}",
+        f"deed.{language_default}",
+    )
     legal_code = get_object_or_404(
         LegalCode,
-        deed_url=request.path,
+        deed_url=default_deed_url,
     )
+
     legal_code_rel_path = os.path.relpath(
         legal_code.legal_code_url, path_start
     )
@@ -195,12 +227,9 @@ def view_deed(
         category,
         license,
     )
-    language_code = legal_code.language_code  # CC language code
-    languages_and_links = get_languages_and_links_for_legal_codes(
-        path_start=path_start,
-        legal_codes=license.legal_codes.all(),
+    languages_and_links = get_languages_and_links_for_deeds_ux(
+        request_path=request.path,
         selected_language_code=language_code,
-        legal_code_or_deed="deed",
     )
 
     if license.unit in UNITS_LICENSES:
@@ -214,23 +243,23 @@ def view_deed(
     else:
         body_template = "includes/deed_body_unimplemented.html"
 
-    translation = legal_code.get_translation_object()
-    with active_translation(translation):
-        return render(
-            request,
-            template_name="deed.html",
-            context={
-                "additional_classes": "",
-                "body_template": body_template,
-                "category": category,
-                "category_title": category_title,
-                "identifier": license.identifier(),
-                "languages_and_links": languages_and_links,
-                "legal_code": legal_code,
-                "license": license,
-                "legal_code_rel_path": legal_code_rel_path,
-            },
-        )
+    django_language_code = cc_to_django_language_code(language_code)
+    translation.activate(django_language_code)
+    return render(
+        request,
+        template_name="deed.html",
+        context={
+            "additional_classes": "",
+            "body_template": body_template,
+            "category": category,
+            "category_title": category_title,
+            "identifier": license.identifier(),
+            "languages_and_links": languages_and_links,
+            "legal_code": legal_code,
+            "legal_code_rel_path": legal_code_rel_path,
+            "license": license,
+        },
+    )
 
 
 def view_legal_code(
@@ -282,16 +311,16 @@ def view_legal_code(
         context={
             "category": category,
             "category_title": category_title,
+            "deed_rel_path": deed_rel_path,
             "identifier": license.identifier(),
             "languages_and_links": languages_and_links,
             "legal_code": legal_code,
             "license": license,
-            "deed_rel_path": deed_rel_path,
         },
     )
 
-    translation = legal_code.get_translation_object()
-    with active_translation(translation):
+    current_translation = legal_code.get_translation_object()
+    with active_translation(current_translation):
         # NOTE: plaintext functionality disabled
         # if is_plain_text:
         #     response = HttpResponse(
@@ -333,9 +362,9 @@ def view_translation_status(request):
         request,
         template_name="dev/translation_status.html",
         context={
+            "branches": branches,
             "category": "dev",
             "category_title": "Dev",
-            "branches": branches,
         },
     )
 
@@ -357,11 +386,11 @@ def branch_status_helper(repo, translation_branch):
     # Copy the data we need into a list of dictionaries
     commits_for_template = [
         {
-            "shorthash": c.hexsha[:7],
-            "hexsha": c.hexsha,
-            "message": c.message,
             "committed_datetime": c.committed_datetime,
             "committer": c.committer,
+            "hexsha": c.hexsha,
+            "message": c.message,
+            "shorthash": c.hexsha[:7],
         }
         for c in last_n_commits
     ]


### PR DESCRIPTION
## Fixes
Fixes [[Bug] Deed/UX translations and Legalcode translations must be distinct and fully represented · Issue #146](https://github.com/creativecommons/cc-licenses/issues/146) 

## Description

Improve translation handling

### .github/workflows/pre-commit.yml
- also checkout  [`cc-licenses-data`](https://github.com/creativecommons/cc-licenses-data) and set `DATA_REPOSITORY_DIR` environment variable 

### cc_licenses/settings/base.py
- Add Aragonese to Django languages
- Remove Language fallbacks that are unnecessary with `i18n.utils.cc_to_django_language_code()` update
-  use UTC for time zone

### i18n/__init__.py
- Correct case in `DEFAULT_JURISDICTION_LANGUAGES` entries
- Remove `DJANGO_LANGUAGE_CODES` entries that are no longer needed  with `i18n.utils.cc_to_django_language_code()` was update

### i18n/utils.py
- Improve `cc_to_django_language_code()` to solve generic cases (ex.`_` => `-`).

### licenses/apps.py
- added PO file scanning to build a list of translations that are 80% or more complete (`settings.LANGUAGES_TRANSLATED`)

###  licenses/templates/dev/home.html
- call trans template tag 2 times instead of 1,876 times

### licenses/views.py
 - Add `get_languages_and_links_for_deeds_ux()` function so Deeds can use any language in `settings.LANGUAGES_TRANSLATED`
 - Add `get_deed_rel_path()` and`get_legal_code_rel_path()` so that the selected language is sticky between Deed and Legal code views (fails to default language).
 - Reorganize functions and sort `context` dictionary entries
 
## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      0     36      3    97.48%   70->exit, 124->126, 140->145
licenses/models.py        246      1     52      2    98.99%   552->560, 609
licenses/transifex.py     201      0     42      1    99.59%   285->293
licenses/utils.py         167      1     78      1    99.18%   59
licenses/views.py         152      8     56      4    92.31%   83, 132, 237, 295-300
----------------------------------------------------------------------
TOTAL                    1058     10    308     11    98.17%

15 files skipped due to complete coverage.
```

## Documentation
- [trans template tag | Translation | Django documentation | Django](https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#trans-template-tag)
- [percent_translated() — polib API — polib 1.0.2 documentation](https://polib.readthedocs.io/en/1.0.2/api.html#polib.POFile.percent_translated)
- [Get the ratio of translation in a Django (or Python) project - Stack Overflow](https://stackoverflow.com/questions/61991861/get-the-ratio-of-translation-in-a-django-or-python-project) (unanswered 😢)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- `N/A` I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
