### PR TITLE
Improve metadata.yaml

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -198,8 +198,6 @@ JURISDICTION_NAMES = {
     "vn": "Vietnam",
     "za": "South Africa",
 }
-
-
 LANGUAGE_CODE_REGEX_STRING = r"[a-zA-Z_-]*"
 DJANGO_LANGUAGE_CODES = {
     # CC language code: django language code

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -190,8 +190,8 @@ def get_default_language_for_jurisdiction(
     # Output: a CC language code
     return DEFAULT_JURISDICTION_LANGUAGES.get(
         jurisdiction_code, default_language
+    )
 
-        )
 
 def get_jurisdiction_name(category, unit, version, jurisdiction_code):
     jurisdiction_name = JURISDICTION_NAMES.get(

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -17,6 +17,7 @@ from i18n import (
     DEFAULT_LANGUAGE_CODE,
     DJANGO_LANGUAGE_CODES,
     FILENAME_LANGUAGE_CODES,
+    JURISDICTION_NAMES,
 )
 
 CACHED_APPLICABLE_LANGS = {}
@@ -189,7 +190,25 @@ def get_default_language_for_jurisdiction(
     # Output: a CC language code
     return DEFAULT_JURISDICTION_LANGUAGES.get(
         jurisdiction_code, default_language
+
+        )
+
+def get_jurisdiction_name(category, unit, version, jurisdiction_code):
+    jurisdiction_name = JURISDICTION_NAMES.get(
+        jurisdiction_code, jurisdiction_code
     )
+    # For details on nomenclature for unported licenses, see:
+    # https://wiki.creativecommons.org/wiki/License_Versions
+    if unit in ["zero", "mark"]:
+        jurisdiction_name = "Universal"
+    elif category == "licenses" and jurisdiction_name.lower() == "unported":
+        if version == "4.0":
+            jurisdiction_name = "International"
+        elif version == "3.0":
+            jurisdiction_name = "International (unported)"
+        else:
+            jurisdiction_name = "Generic (unported)"
+    return jurisdiction_name
 
 
 def get_locale_text_orientation(locale_identifier: str) -> str:

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -1029,13 +1029,15 @@ class Command(BaseCommand):
             title_html = soup.find(id="deed").p.strong
             title = inner_html(title_html)
             title_html.find_parent("p").decompose()
-        # Title clean-up: whitespace
+        # Title clean-up: whitespace, part 1
         title = " ".join([line.strip() for line in title.split("\n")]).strip()
         # Title clean-up: remove manual break
         title = title.replace("<br/>", "")
         # Title clean-up: remove strong
         title = title.replace("<strong>", "").replace("</strong>", "")
         assert "<" not in title, repr(title)
+        # Title clean-up: whitespace, part 2
+        title = title.strip()
         legal_code.title = title
 
         # Remove legacy header images

--- a/licenses/templates/dev/home.html
+++ b/licenses/templates/dev/home.html
@@ -31,6 +31,7 @@ the generation of static files.
       <h2 id="develoment">Development</h2>
       <p><a href="/dev/admin/">Django administration</a></p>
       <p><a href="{% url 'dev_404' %}">Error 404</a></p>
+      <p><a href="{% url 'metadata' %}">metadata.yaml</a></p>
 
       <h2 id="translations">Translation</h2>
       <p><a href="{% url 'translation_status' %}">Translation status</a></p>
@@ -46,20 +47,20 @@ the generation of static files.
           {% regroup identifier_group.list by version as version_list %}
           {% for version_group in version_list %}
             {% with version=version_group.grouper %}
-              {% regroup version_group.list by jurisdiction as jurisdiction_list %}
-              {% for jurisdiction_group in jurisdiction_list %}
-                <h5>{{ jurisdiction_group.grouper }}</h5>
+              {% regroup version_group.list by jurisdiction_name as jurisdiction_name_list %}
+              {% for jurisdiction_name_group in jurisdiction_name_list %}
+                <h5>{{ jurisdiction_name_group.grouper }}</h5>
                 <table>
                   <thead>
                   <tr>
                     <th>Language</th>
-                    {% for code in jurisdiction_group.list|units %}
+                    {% for code in jurisdiction_name_group.list|units %}
                       <th>{{ code }}</th>
                     {% endfor %}
                   </tr>
                   </thead>
                   <tbody>
-                    {% regroup jurisdiction_group.list by language_code as language_list %}
+                    {% regroup jurisdiction_name_group.list by language_code as language_list %}
                     {% for legal_code_group in language_list %}
                       <tr>
                         <th>{{ legal_code_group.grouper }}</th>
@@ -86,20 +87,20 @@ the generation of static files.
       {% for version_group in version_list %}
         {% with version=version_group.grouper %}
         <h4>{{ version }} Licenses</h4>
-          {% regroup version_group.list by jurisdiction as jurisdiction_list %}
-          {% for jurisdiction_group in jurisdiction_list %}
-            <h5>{{ version }} {{ jurisdiction_group.grouper }}</h5>
+          {% regroup version_group.list by jurisdiction_name as jurisdiction_name_list %}
+          {% for jurisdiction_name_group in jurisdiction_name_list %}
+            <h5>{{ version }} {{ jurisdiction_name_group.grouper }}</h5>
             <table>
               <thead>
               <tr>
                 <th>Language</th>
-                {% for code in jurisdiction_group.list|units %}
+                {% for code in jurisdiction_name_group.list|units %}
                   <th>{{ code }}</th>
                 {% endfor %}
               </tr>
               </thead>
               <tbody>
-                {% regroup jurisdiction_group.list by language_code as language_list %}
+                {% regroup jurisdiction_name_group.list by language_code as language_list %}
                 {% for legal_code_group in language_list %}
                   <tr>
                     <th>{{ legal_code_group.grouper }}</th>

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -532,7 +532,7 @@ class LicenseModelTest(TestCase):
 
         data = license.get_metadata()
         expected_data = {
-            "jurisdiction": "xyz",
+            "jurisdiction_name": "xyz",
             "unit": "by-nc",
             "permits_derivative_works": False,
             "permits_distribution": True,
@@ -544,15 +544,9 @@ class LicenseModelTest(TestCase):
             "requires_notice": True,
             "requires_share_alike": True,
             "requires_source_code": True,
-            "translations": {
-                "en": {
-                    "deed": "/licenses/by-nc/3.0/xyz/deed.en",
-                    "license": "/licenses/by-nc/3.0/xyz/legalcode.en",
-                },
-                "pt": {
-                    "deed": "/licenses/by-nc/3.0/xyz/deed.pt",
-                    "license": "/licenses/by-nc/3.0/xyz/legalcode.pt",
-                },
+            "legal_code_languages": {
+                "en": "English",
+                "pt": "Portuguese",
             },
             "version": "3.0",
         }
@@ -599,11 +593,8 @@ class LicenseModelTest(TestCase):
             "requires_notice": True,
             "requires_share_alike": True,
             "requires_source_code": True,
-            "translations": {
-                "en": {
-                    "deed": "/licenses/by-nc/3.0/deed.en",
-                    "license": "/licenses/by-nc/3.0/legalcode.en",
-                },
+            "legal_code_languages": {
+                "en": "English",
             },
         }
 


### PR DESCRIPTION
## Description
Improve data representation within metadata.yaml

- improve crude html title clean-up
- add `get_jurisdiction_name()` function
- Add metadata.yaml download to Dev Home page template
- Update data contained within metadata.yaml
  - organize by category
  - include missing fields
  - better represent legal code translations
- Complete test coverage for views
- Reorganize and rename view tests to reflect views code

## Technical details
### New/metadata-yaml `metadata.yaml` Excerpt
```yaml
licenses:
- by_40:
    canonical_url: https://creativecommons.org/licenses/by/4.0/
    deed_only: false
    identifier: CC BY 4.0
    jurisdiction_name: International
    legal_code_languages:
      ar: Arabic
      cs: Czech
      # [...]
      zh-Hans: Simplified Chinese
      zh-Hant: Traditional Chinese
    permits_derivative_works: true
    permits_distribution: true
    permits_reproduction: true
    permits_sharing: true
    prohibits_commercial_use: false
    prohibits_high_income_nation_use: false
    requires_attribution: true
    requires_notice: true
    requires_share_alike: false
    requires_source_code: false
    title: Attribution 4.0 International
    unit: by
    version: '4.0'
```

### Old/main `metadata.yaml` Excerpt
```yaml
- deed_only: false
  permits_derivative_works: true
  permits_distribution: true
  permits_reproduction: true
  permits_sharing: true
  prohibits_commercial_use: false
  prohibits_high_income_nation_use: false
  requires_attribution: true
  requires_notice: true
  requires_share_alike: false
  requires_source_code: false
  translations:
    ar:
      deed: /licenses/by/4.0/deed.ar
      license: /licenses/by/4.0/legalcode.ar
    cs:
      deed: /licenses/by/4.0/deed.cs
      license: /licenses/by/4.0/legalcode.cs
    # [...]
    zh-Hans:
      deed: /licenses/by/4.0/deed.zh-Hans
      license: /licenses/by/4.0/legalcode.zh-Hans
    zh-Hant:
      deed: /licenses/by/4.0/deed.zh-Hant
      license: /licenses/by/4.0/legalcode.zh-Hant
  unit: by
  version: '4.0'
```

### Documentation
-  [PyYAML Documentation](https://pyyaml.org/wiki/PyYAMLDocumentation)

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      0     36      3    97.48%   70->exit, 124->126, 140->145
licenses/models.py        261      2     58      3    98.43%   519, 526, 536->543
licenses/transifex.py     201      0     42      1    99.59%   285->293
licenses/utils.py         167      1     78      1    99.18%   59
----------------------------------------------------------------------
TOTAL                    1080      3    314      8    99.21%

16 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
