### PR TITLE
Improve transifex test coverage

### DIFF
--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -1207,7 +1207,7 @@ class TestTransifex(TestCase):
                         },
                     }
                     with mpo(polib.POFile, "save") as mock_pofile_save:
-                        new_pofile_obj = self.helper.normalize_pofile_dates(
+                        self.helper.normalize_pofile_dates(
                             transifex_code,
                             resource_slug,
                             resource_name,

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -896,6 +896,28 @@ class TestTransifex(TestCase):
             resource_slug, new_pofile_obj.metadata["Project-Id-Version"]
         )
 
+    # Test: normalize_pofile_metadata ########################################
+
+    def test_normalize_pofile_metadata(self):
+        self.helper.dryrun = True
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = self.helper.normalize_pofile_metadata(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_not_called()
+        self.assertEqual(pofile_obj, new_pofile_obj)
+
     # def test_update_source_messages(self):
     #     with mpo(self.helper, "request20") as mock_request:
     #         self.helper.update_source_messages(

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -601,6 +601,7 @@ class TestTransifex(TestCase):
             )
 
         mock_pofile_save.assert_called()
+        self.assertIn("Language", new_pofile_obj.metadata)
         self.assertEqual(new_pofile_obj.metadata["Language"], transifex_code)
 
     def test_noramalize_pofile_language_incorrect(self):
@@ -664,7 +665,7 @@ class TestTransifex(TestCase):
 
     def test_normalize_pofile_language_team_dryrun(self):
         self.helper.dryrun = True
-        transifex_code = "en"
+        transifex_code = "x_trans_code_x"
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
         pofile_path = "x_path_x"
@@ -708,7 +709,7 @@ class TestTransifex(TestCase):
         del pofile_obj.metadata["Language-Team"]
 
         with mpo(polib.POFile, "save") as mock_pofile_save:
-            self.helper.normalize_pofile_language_team(
+            new_pofile_obj = self.helper.normalize_pofile_language_team(
                 transifex_code,
                 resource_slug,
                 resource_name,
@@ -717,6 +718,86 @@ class TestTransifex(TestCase):
             )
 
         mock_pofile_save.assert_called()
+        self.assertIn("Language-Team", new_pofile_obj.metadata)
+
+    def test_normalize_pofile_last_translator_missing(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata.pop("Last-Translator", None)
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = self.helper.normalize_pofile_last_translator(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_not_called()
+        self.assertNotIn("Last-Translator", new_pofile_obj.metadata)
+
+    def test_normalize_pofile_last_translator_correct(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata["Last-Translator"] = "valid_email@example.com"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            self.helper.normalize_pofile_last_translator(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_not_called()
+
+    def test_normalize_pofile_last_translator_dryrun(self):
+        self.helper.dryrun = True
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata["Last-Translator"] = "FULL NAME <EMAIL@ADDRESS>"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            self.helper.normalize_pofile_last_translator(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_not_called()
+
+    def test_normalize_pofile_last_translator_incorrect(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata["Last-Translator"] = "FULL NAME <EMAIL@ADDRESS>"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = self.helper.normalize_pofile_last_translator(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_called()
+        self.assertNotIn("Last-Translator", new_pofile_obj.metadata)
 
     # def test_update_source_messages(self):
     #     with mpo(self.helper, "request20") as mock_request:

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -972,6 +972,60 @@ class TestTransifex(TestCase):
             new_pofile_obj.metadata["POT-Creation-Date"], transifex_creation
         )
 
+    # Test: update_pofile_revision_to_match_transifex ########################
+
+    def test_update_pofile_revision_to_match_transifex_dryrun(self):
+        self.helper.dryrun = True
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_revision = "2021-01-01 01:01:01.000001+00:00"
+        pofile_obj.metadata["PO-Revision-Date"] = pofile_revision
+        transifex_revision = "2021-02-02 02:02:02.000002+00:00"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            self.helper.update_pofile_revision_to_match_transifex(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+                pofile_revision,
+                transifex_revision,
+            )
+
+        mock_pofile_save.assert_not_called()
+
+    def test_update_pofile_revision_to_match_transifex_save(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_revision = "2021-01-01 01:01:01.000001+00:00"
+        pofile_obj.metadata["PO-Revision-Date"] = pofile_revision
+        transifex_revision = "2021-02-02 02:02:02.000002+00:00"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = (
+                self.helper.update_pofile_revision_to_match_transifex(
+                    transifex_code,
+                    resource_slug,
+                    resource_name,
+                    pofile_path,
+                    pofile_obj,
+                    pofile_revision,
+                    transifex_revision,
+                )
+            )
+
+        mock_pofile_save.assert_called()
+        self.assertEqual(
+            new_pofile_obj.metadata["PO-Revision-Date"], transifex_revision
+        )
+
     # def test_update_source_messages(self):
     #     with mpo(self.helper, "request20") as mock_request:
     #         self.helper.update_source_messages(

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -918,6 +918,60 @@ class TestTransifex(TestCase):
         mock_pofile_save.assert_not_called()
         self.assertEqual(pofile_obj, new_pofile_obj)
 
+    # Test: update_pofile_creation_to_match_transifex ########################
+
+    def test_update_pofile_creation_to_match_transifex_dryrun(self):
+        self.helper.dryrun = True
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_creation = "2021-01-01 01:01:01.000001+00:00"
+        pofile_obj.metadata["POT-Creation-Date"] = pofile_creation
+        transifex_creation = "2021-02-02 02:02:02.000002+00:00"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            self.helper.update_pofile_creation_to_match_transifex(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+                pofile_creation,
+                transifex_creation,
+            )
+
+        mock_pofile_save.assert_not_called()
+
+    def test_update_pofile_creation_to_match_transifex_save(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_creation = "2021-01-01 01:01:01.000001+00:00"
+        pofile_obj.metadata["POT-Creation-Date"] = pofile_creation
+        transifex_creation = "2021-02-02 02:02:02.000002+00:00"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = (
+                self.helper.update_pofile_creation_to_match_transifex(
+                    transifex_code,
+                    resource_slug,
+                    resource_name,
+                    pofile_path,
+                    pofile_obj,
+                    pofile_creation,
+                    transifex_creation,
+                )
+            )
+
+        mock_pofile_save.assert_called()
+        self.assertEqual(
+            new_pofile_obj.metadata["POT-Creation-Date"], transifex_creation
+        )
+
     # def test_update_source_messages(self):
     #     with mpo(self.helper, "request20") as mock_request:
     #         self.helper.update_source_messages(

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -285,6 +285,8 @@ class TestTransifex(TestCase):
             list(local_data["by_40"]["translations"].keys()), ["de"]
         )
 
+    # Test: add_resource_to_transifex ########################################
+
     def test_add_resource_to_transifex_missing(self):
         language_code = "x_lang_code_x"
         resource_slug = "x_slug_x"
@@ -364,6 +366,8 @@ class TestTransifex(TestCase):
             )
 
         mock_request.assert_not_called()
+
+    # Test: add_translation_to_transifex_resource ############################
 
     def test_add_translation_to_transifex_resource_is_source(self):
         language_code = DEFAULT_LANGUAGE_CODE
@@ -546,6 +550,8 @@ class TestTransifex(TestCase):
             ],
         )
 
+    # Test: normalize_pofile_language ########################################
+
     def test_noramalize_pofile_language_correct(self):
         transifex_code = "en"
         resource_slug = "x_slug_x"
@@ -622,6 +628,8 @@ class TestTransifex(TestCase):
 
         mock_pofile_save.assert_called()
         self.assertEqual(new_pofile_obj.metadata["Language"], transifex_code)
+
+    # Test: normalize_pofile_language_team ###################################
 
     def test_normalize_pofile_language_team_source_correct(self):
         transifex_code = "en"
@@ -720,6 +728,8 @@ class TestTransifex(TestCase):
         mock_pofile_save.assert_called()
         self.assertIn("Language-Team", new_pofile_obj.metadata)
 
+    # Test: normalize_pofile_last_translator #################################
+
     def test_normalize_pofile_last_translator_missing(self):
         transifex_code = "x_trans_code_x"
         resource_slug = "x_slug_x"
@@ -798,6 +808,93 @@ class TestTransifex(TestCase):
 
         mock_pofile_save.assert_called()
         self.assertNotIn("Last-Translator", new_pofile_obj.metadata)
+
+    # Test: normalize_pofile_project_id ######################################
+
+    def test_normalize_pofile_project_id_correct(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata["Project-Id-Version"] = resource_slug
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            self.helper.normalize_pofile_project_id(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_not_called()
+
+    def test_normalize_pofile_project_id_dryrun(self):
+        self.helper.dryrun = True
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata["Project-Id-Version"] = "PACKAGE VERSION"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            self.helper.normalize_pofile_project_id(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_not_called()
+
+    def test_normalize_pofile_project_id_incorrect(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata["Project-Id-Version"] = "PACKAGE VERSION"
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = self.helper.normalize_pofile_project_id(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_called()
+        self.assertIn("Project-Id-Version", new_pofile_obj.metadata)
+        self.assertEqual(
+            resource_slug, new_pofile_obj.metadata["Project-Id-Version"]
+        )
+
+    def test_normalize_pofile_project_id_missing(self):
+        transifex_code = "x_trans_code_x"
+        resource_slug = "x_slug_x"
+        resource_name = "x_name_x"
+        pofile_path = "x_path_x"
+        pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
+        pofile_obj.metadata.pop("Project-Id-Version", None)
+
+        with mpo(polib.POFile, "save") as mock_pofile_save:
+            new_pofile_obj = self.helper.normalize_pofile_project_id(
+                transifex_code,
+                resource_slug,
+                resource_name,
+                pofile_path,
+                pofile_obj,
+            )
+
+        mock_pofile_save.assert_called()
+        self.assertIn("Project-Id-Version", new_pofile_obj.metadata)
+        self.assertEqual(
+            resource_slug, new_pofile_obj.metadata["Project-Id-Version"]
+        )
 
     # def test_update_source_messages(self):
     #     with mpo(self.helper, "request20") as mock_request:

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -803,7 +803,7 @@ class TransifexHelper:
                 )
         return pofile_obj
 
-    def normalize_translations(self):
+    def normalize_translations(self):  # pragma: no cover
         legal_codes = (
             licenses.models.LegalCode.objects.valid()
             .translated()

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -919,7 +919,7 @@ class TransifexHelper:
         repo: git.Repo,
         legal_codes: Iterable["licenses.models.LegalCode"],
         update_repo=False,
-    ):
+    ):  # pragma: no cover
         """
         Use the Transifex API to find the last update timestamp for all our
         translations.  If translations are updated, we'll create a branch if
@@ -981,7 +981,7 @@ class TransifexHelper:
     def check_for_translation_updates(
         self,
         update_repo=False,
-    ):
+    ):  # pragma: no cover
         """
         This function wraps
         check_for_translation_updates_with_repo_and_legal_codes() to make

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -682,7 +682,7 @@ class TransifexHelper:
         )
         if self.dryrun:
             return pofile_obj
-        pofile_obj.metadata["POT-Creation-Date"] = transifex_creation
+        pofile_obj.metadata["POT-Creation-Date"] = str(transifex_creation)
         pofile_obj.save(pofile_path)
         return pofile_obj
 

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -610,11 +610,7 @@ class TransifexHelper:
         pofile_obj,
     ):
         key = "Project-Id-Version"
-        filler_data = "PACKAGE VERSION"
-        if (
-            key in pofile_obj.metadata
-            and pofile_obj.metadata[key] != filler_data
-        ) or pofile_obj.metadata[key] == resource_slug:
+        if pofile_obj.metadata.get(key, None) == resource_slug:
             return pofile_obj
 
         self.log.info(

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -706,7 +706,7 @@ class TransifexHelper:
         )
         if self.dryrun:
             return pofile_obj
-        pofile_obj.metadata["PO-Revision-Date"] = transifex_revision
+        pofile_obj.metadata["PO-Revision-Date"] = str(transifex_revision)
         pofile_obj.save(pofile_path)
         return pofile_obj
 

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -664,11 +664,11 @@ class TransifexHelper:
 
     def update_pofile_creation_to_match_transifex(
         self,
-        resource_slug,
         transifex_code,
+        resource_slug,
         resource_name,
-        pofile_obj,
         pofile_path,
+        pofile_obj,
         pofile_creation,
         transifex_creation,
     ):
@@ -688,11 +688,11 @@ class TransifexHelper:
 
     def update_pofile_revision_to_match_transifex(
         self,
+        transifex_code,
         resource_slug,
         resource_name,
-        transifex_code,
-        pofile_obj,
         pofile_path,
+        pofile_obj,
         pofile_revision,
         transifex_revision,
     ):
@@ -712,11 +712,11 @@ class TransifexHelper:
 
     def normalize_pofile_dates(
         self,
+        transifex_code,
         resource_slug,
         resource_name,
-        transifex_code,
-        pofile_obj,
         pofile_path,
+        pofile_obj,
     ):
         pad = len(pofile_path)
         pofile_creation = get_pofile_creation_date(pofile_obj)
@@ -734,11 +734,11 @@ class TransifexHelper:
         if pofile_creation is None or transifex_creation < pofile_creation:
             # Normalize Local PO File revision date if its empty or invalid
             pofile_obj = self.update_pofile_creation_to_match_transifex(
+                transifex_code,
                 resource_slug,
                 resource_name,
-                transifex_code,
-                pofile_obj,
                 pofile_path,
+                pofile_obj,
                 pofile_creation,
                 transifex_creation,
             )
@@ -755,11 +755,11 @@ class TransifexHelper:
         if pofile_revision is None:
             # Normalize Local PO File revision date if its empty or invalid
             pofile_obj = self.update_pofile_revision_to_match_transifex(
+                transifex_code,
                 resource_slug,
                 resource_name,
-                transifex_code,
-                pofile_obj,
                 pofile_path,
+                pofile_obj,
                 pofile_revision,
                 transifex_revision,
             )
@@ -786,11 +786,11 @@ class TransifexHelper:
             # entries and the Transifex PO File entries are the same.
             if po_entries_are_the_same:
                 pofile_obj = self.update_pofile_revision_to_match_transifex(
+                    transifex_code,
                     resource_slug,
                     resource_name,
-                    transifex_code,
-                    pofile_obj,
                     pofile_path,
+                    pofile_obj,
                     pofile_revision,
                     transifex_revision,
                 )
@@ -844,11 +844,11 @@ class TransifexHelper:
                 pofile_obj,
             )
             pofile_obj = self.normalize_pofile_dates(
+                transifex_code,
                 resource_slug,
                 resource_name,
-                transifex_code,
-                pofile_obj,
                 pofile_path,
+                pofile_obj,
             )
             # # UpdateSource
             # # We're doing English, which is the source language.
@@ -907,11 +907,11 @@ class TransifexHelper:
 
                 # Normalize Creation and Revision dates in local PO files
                 pofile_obj = self.normalize_pofile_dates(
+                    transifex_code,
                     resource_slug,
                     resource_name,
-                    transifex_code,
-                    pofile_obj,
                     pofile_path,
+                    pofile_obj,
                 )
 
     def check_for_translation_updates_with_repo_and_legal_codes(


### PR DESCRIPTION
## Description
- Improve transifex test coverage from 64.03% to 100%
  - (total test coverage from 91.25% to 99.67%)
- Minor corections to `licenses/transifex.py`:
  - improve consistency of argument order
  - store date as string instead of object (for easier testing)
  - simplify and correct logic within `normalize_pofile_project_id()`

## Technical details
- [Coverage.py][coveragepy]: Code coverage measurement for Python
- [unittest — Unit testing framework — Python 3.7.11 documentation](https://docs.python.org/3.7/library/unittest.html)
- [unittest.mock — mock object library — Python 3.7.11 documentation](https://docs.python.org/3.7/library/unittest.mock.html)
- [Testing in Django | Django documentation | Django](https://docs.djangoproject.com/en/3.2/topics/testing/)

[coveragepy]: https://github.com/nedbat/coveragepy

## Tests
### Before This PR
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
licenses/transifex.py     285     95     82      1    64.03%   572, 585-602, 612-629, 639-667, 679-691, 703-715, 725-808, 811-913, 937, 994
----------------------------------------------------------------------
TOTAL                    1209     97    356      4    91.25%

18 files skipped due to complete coverage.
Coverage failure: total of 91.25 is less than fail-under=98.00
```

### With This PR
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
----------------------------------------------------------------------
TOTAL                    1179      2    348      3    99.67%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
