### PR TITLE
switch language code to oc-aranes (Code)

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -246,8 +246,6 @@ LANGMAP_DJANGO_TO_TRANSIFEX = {
     "fa-ir": "fa_IR",
     "fr-ca": "fr_CA",
     "fr-ch": "fr_CH",
-    # "oc-aranes": "oc@aranes",  # .. until Aranese is added to Transifex
-    "oc-aranes": "oc",  # Use Occitan until Aranese is added to Transifex
     "pt-br": "pt_BR",
     "si-lk": "si_LK",
     "sr-latn": "sr@latin",

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -247,7 +247,7 @@ class MappingTest(TestCase):
         self.assertEqual("de_AT", transifex_code)
 
         transifex_code = map_django_to_transifex_language_code("oc-aranes")
-        self.assertEqual("oc", transifex_code)
+        self.assertEqual("oc-aranes", transifex_code)
 
         transifex_code = map_django_to_transifex_language_code("sr-latn")
         self.assertEqual("sr@latin", transifex_code)


### PR DESCRIPTION
## Fixes
Fixes #165
- #165

## Description
switch language code to `oc-aranes` now that it is supported by Transifex (Code)

## Technical details
- See [Language Codes - README](https://github.com/creativecommons/cc-licenses#language-codes).
- Data PR: [switch language code to oc-aranes (Data) by TimidRobot · Pull Request #30 · creativecommons/cc-licenses-data](https://github.com/creativecommons/cc-licenses-data/pull/30)

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
----------------------------------------------------------------------
TOTAL                    1240      2    364      3    99.69%

19 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
