### PR TITLE
Use locale name for translation directories and add metadata (code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ data/
 
 # IDE ignores
 .vscode
+
+# Container files
+.bash_history
+.ssh

--- a/cc_licenses/settings/base.py
+++ b/cc_licenses/settings/base.py
@@ -6,8 +6,6 @@ import os
 
 # Third-party
 import colorlog  # noqa: F401
-from babel import Locale
-from babel.core import UnknownLocaleError
 from django.conf.locale import LANG_INFO
 
 APP_NAME = "licenses"
@@ -213,7 +211,7 @@ LOCALE_PATHS = (
     LEGAL_CODE_LOCALE_PATH,
 )
 
-# Teach Django about a few more languages (sorted by langauge code):
+# Teach Django about a few more languages (sorted by language code)
 
 # Aragonese
 LANG_INFO["an"] = {
@@ -247,24 +245,8 @@ LANG_INFO["si-lk"] = {"code": "si-lk"}  # Remaining data from Babel
 # Zulu
 LANG_INFO["zu"] = {"code": "zu"}  # Remaining data from Babel
 
-# Normalize languages using Babel
-order_to_bidi = {
-    "left-to-right": False,
-    "right-to-left": True,
-}
-for language_code in LANG_INFO.keys():
-    babel_code = language_code.replace("-", "_")
-    try:
-        locale = Locale.parse(babel_code)
-        lang_info = LANG_INFO[language_code]
-        lang_info["name"] = locale.get_display_name("en")
-        lang_info["name_local"] = locale.get_display_name(babel_code)
-        lang_info["bidi"] = order_to_bidi[locale.character_order]
-    except UnknownLocaleError:
-        continue
-
 TRANSIFEX = {
-    "API_TOKEN": os.getenv("TRANSIFEX_API_TOKEN", "missing"),
+    "API_TOKEN": os.getenv("TRANSIFEX_API_TOKEN", "[!] MISSING [!]"),
     "ORGANIZATION_SLUG": "creativecommons",
     "PROJECT_SLUG": "CC",
     # We currently only have a single team for all of our projects named

--- a/i18n/tests/test_utils.py
+++ b/i18n/tests/test_utils.py
@@ -47,9 +47,13 @@ class TranslationTest(TestCase):
     def test_get_translation_object(self):
         translation_object = MagicMock()
 
-        with mock.patch("i18n.utils.trans_real.DjangoTranslation") as mock_djt:
+        with mock.patch(
+            "i18n.utils.translation.trans_real.DjangoTranslation"
+        ) as mock_djt:
             mock_djt.return_value = translation_object
-            with mock.patch("i18n.utils.trans_real.translation") as mock_trans:
+            with mock.patch(
+                "i18n.utils.translation.trans_real.translation"
+            ) as mock_trans:
                 result = get_translation_object(
                     django_language_code="LANGUAGE_CODE",
                     domain="GETTEXT_DOMAIN",

--- a/licenses/apps.py
+++ b/licenses/apps.py
@@ -3,7 +3,7 @@ from django.apps import AppConfig
 from django.conf import settings
 
 # First-party/Local
-from i18n.utils import load_deeds_ux_translations
+from i18n.utils import load_deeds_ux_translations, update_lang_info
 from licenses.git_utils import setup_to_call_git
 
 
@@ -17,4 +17,11 @@ class LicensesConfig(AppConfig):
 
     def ready(self):
         setup_to_call_git()
+
+        # Normalize all currently loaded language information using Babel
+        for language_code in settings.LANG_INFO.keys():
+            update_lang_info(language_code)
+
+        # Process Deed & UX translations (store information on all, load those
+        # that meet or exceed the TRANSLATION_THRESHOLD).
         load_deeds_ux_translations()

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -9,7 +9,6 @@ from argparse import ArgumentParser
 from bs4 import BeautifulSoup, Tag
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
-from django.utils.translation import to_locale
 from polib import POEntry, POFile
 
 # First-party/Local
@@ -388,7 +387,7 @@ class Command(BaseCommand):
         pofile.metadata = {
             "Content-Transfer-Encoding": "8bit",
             "Content-Type": "text/plain; charset=utf-8",
-            "Language": to_locale(language_code),
+            "Language": transifex_language,
             "Language-Django": language_code,
             "Language-Transifex": transifex_language,
             "Language-Team": "https://www.transifex.com/creativecommons/CC/",

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -387,7 +387,9 @@ class Command(BaseCommand):
         pofile.metadata = {
             "Content-Transfer-Encoding": "8bit",
             "Content-Type": "text/plain; charset=utf-8",
-            "Language": transifex_language,
+            "Language": to_locale(language_code),
+            "Language-Django": language_code,
+            "Language-Transifex": transifex_language,
             "Language-Team": "https://www.transifex.com/creativecommons/CC/",
             "MIME-Version": "1.0",
             "PO-Revision-Date": NOW,
@@ -395,9 +397,9 @@ class Command(BaseCommand):
             "Project-Id-Version": legal_code.license.resource_slug,
         }
 
-        dir = os.path.dirname(po_filename)
-        if not os.path.isdir(dir):
-            os.makedirs(dir)
+        directory = os.path.dirname(po_filename)
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
         # Save mofile ourself. We could call 'compilemessages' but
         # it wants to compile everything, which is both overkill
         # and can fail if the venv or project source is not

--- a/licenses/management/commands/load_html_files.py
+++ b/licenses/management/commands/load_html_files.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser
 from bs4 import BeautifulSoup, Tag
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
+from django.utils.translation import to_locale
 from polib import POEntry, POFile
 
 # First-party/Local

--- a/licenses/models.py
+++ b/licenses/models.py
@@ -15,7 +15,6 @@ import posixpath
 
 # Third-party
 import polib
-from django.conf import settings
 from django.db import models
 from django.db.models import Q
 from django.utils import translation
@@ -25,6 +24,7 @@ from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import (
     get_default_language_for_jurisdiction,
     get_jurisdiction_name,
+    get_pofile_path,
     get_translation_object,
     map_django_to_redirects_language_codes,
     map_django_to_redirects_language_codes_lowercase,
@@ -423,32 +423,13 @@ class LegalCode(models.Model):
     def translation_filename(self):
         """
         Return absolute path to the .po file with this translation.
-        These are in the cc-licenses-data repository, in subdirectories:
-          - "legalcode/"
-          - language code
-          - "LC_MESSAGES/"  (Django insists on this)
-          - files
-
-        The filenames are {resource_slug}.po (get the resource_slug
-        from the license).
-
-        e.g. for the BY-NC 4.0 French translation, which has no jurisdiction,
-        the filename will be "by-nc_4.0.po", and in full,
-        "{translation repo topdir}/legalcode/fr/by-nc_4.0.po".
         """
-        filename = f"{self.license.resource_slug}.po"
-        fullpath = os.path.abspath(
-            os.path.realpath(
-                os.path.join(
-                    settings.DATA_REPOSITORY_DIR,
-                    "legalcode",
-                    self.language_code,
-                    "LC_MESSAGES",
-                    filename,
-                )
-            )
+        pofile_path = get_pofile_path(
+            locale_or_legalcode="legalcode",
+            language_code=self.language_code,
+            resource_slug=self.license.resource_slug,
         )
-        return fullpath
+        return pofile_path
 
 
 class License(models.Model):

--- a/licenses/templates/dev/translation_status.html
+++ b/licenses/templates/dev/translation_status.html
@@ -18,60 +18,71 @@
   </style>
 
   <h1>Deed & UX Translation Status</h1>
-  <table border="1">
-  <thead>
+  <table>
+  <thead style="background-color: rgb(245, 245, 245); position: sticky; top: 0px;">
   <tr>
     <th>Django<br>Language Code</th>
+    <th>Django<br>Locale Name</th>
     <th>Transifex<br>Language Code</th>
     <th>Language Name</th>
     <th>Percent<br>Translated</th>
-    <th>Created</th>
-    <th>Updated</th>
+    <th>Created (UTC)</th>
+    <th>Updated (UTC)</th>
     <th>BiDi</th>
     <th>Legal Codes<br>in this language</th>
     <th>Name Local</th>
   </tr>
   </thead>
-  {% for language_code, info in deed_ux.items %}
-    <tr>
-      <td><code>{{ language_code }}</code></td>
-      <td><code>{{ info.transifex_code }}</code></td>
-      <td>{{ info.name|safe }}</td>
-      {% if info.percent_translated == 0 %}
-      <td style="background-color:#ffeeee;text-align:right;">
-      {% elif info.percent_translated < 80 %}
-      <td style="background-color:#ffffee;text-align:right;">
-      {% else %}
-      <td style="background-color:#eeffee;text-align:right;">
-      {% endif %}
-        {{ info.percent_translated }}%
-      </td>
-      <td>{{ info.created }}</td>
-      <td>{{ info.updated }}</td>
-      {% if info.bidi %}
-        <td style="font-weight:bold;text-align:right">
-          RTL &#x21E6 {#&lArr; {# leftwards double arrow #}
-        </td>
-      {% else %}
-        <td style="text-align:left">
-          &#x21E8 {#&rArr; {# rightwards double arrow #} LTR
-        </td>
-      {% endif %}
-      </td>
-      <td style="text-align:center;">
-        {% if info.legal_code %}
-          &#x2714 {# heavy check mark emoji #}
+  </tbody>
+    {% for language_code, info in deed_ux.items %}
+      <tr>
+        {% if language_code == info.locale_name and info.locale_name == info.transifex_code %}
+        <td colspan="3"><code>{{ language_code }}</code></td>
+        {% elif info.locale_name == info.transifex_code %}
+        <td><code>{{ language_code }}</code></td>
+        <td colspan="2"><code>{{ info.locale_name }}</code></td>
+        {% else %}
+        <td><code>{{ language_code }}</code></td>
+        <td><code>{{ info.locale_name }}</code></td>
+        <td><code>{{ info.transifex_code }}</code></td>
         {% endif %}
-      </td>
-      <td>{{ info.name_local }}</td>
-    </tr>
-  {% endfor %}
+        <td>{{ info.name|safe }}</td>
+        {% if info.percent_translated == 0 %}
+        <td style="background-color:#ffeeee;text-align:right;">
+        {% elif info.percent_translated < 80 %}
+        <td style="background-color:#ffffee;text-align:right;">
+        {% else %}
+        <td style="background-color:#eeffee;text-align:right;">
+        {% endif %}
+          {{ info.percent_translated }}%
+        </td>
+        <td>{{ info.created }}</td>
+        <td>{{ info.updated }}</td>
+        {% if info.bidi %}
+          <td style="font-weight:bold;text-align:right">
+            RTL &#x21E6 {#&lArr; {# leftwards double arrow #}
+          </td>
+        {% else %}
+          <td style="text-align:left">
+            &#x21E8 {#&rArr; {# rightwards double arrow #} LTR
+          </td>
+        {% endif %}
+        </td>
+        <td style="text-align:center;">
+          {% if info.legal_code %}
+            &#x2714 {# heavy check mark emoji #}
+          {% endif %}
+        </td>
+        <td>{{ info.name_local }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
   </table>
   <ul>
     <li>Translation inclusion threashold: {{ threshold }}%</li>
     <li>Django Language Codes are <em>lowercase</em> IETF language tags</li>
     <li><em>Some</em> Transifex Language Codes are IETF language tags</li>
-    <li><em>Most</em> Transifex Language Codes are POSIX Locales</li>
+    <li><em>Most</em> Transifex Language Codes are POSIX Locales or Unicode Locales</li>
   </ul>
 
   <h1>Legal Code Translation Status</h1>

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -38,6 +38,8 @@ msgstr ""
 "Project-Id-Version: by-nd_40\n"
 "Language-Team: https://www.transifex.com/{TEST_ORG_SLUG}/{TEST_PROJ_SLUG}/\n"
 "Language: en\n"
+"Language-Django: en\n"
+"Language-Transifex: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -553,6 +555,7 @@ class TestTransifex(TestCase):
     # Test: normalize_pofile_language ########################################
 
     def test_noramalize_pofile_language_correct(self):
+        language_code = "en"
         transifex_code = "en"
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
@@ -561,6 +564,7 @@ class TestTransifex(TestCase):
 
         with mpo(polib.POFile, "save") as mock_pofile_save:
             self.helper.normalize_pofile_language(
+                language_code,
                 transifex_code,
                 resource_slug,
                 resource_name,
@@ -572,6 +576,7 @@ class TestTransifex(TestCase):
 
     def test_noramalize_pofile_language_dryrun(self):
         self.helper.dryrun = True
+        language_code = "en"
         transifex_code = "x_trans_code_x"
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
@@ -580,6 +585,7 @@ class TestTransifex(TestCase):
 
         with mpo(polib.POFile, "save") as mock_pofile_save:
             self.helper.normalize_pofile_language(
+                language_code,
                 transifex_code,
                 resource_slug,
                 resource_name,
@@ -590,15 +596,19 @@ class TestTransifex(TestCase):
         mock_pofile_save.assert_not_called()
 
     def test_noramalize_pofile_language_missing(self):
+        language_code = "x_lang_code_x"
         transifex_code = "x_trans_code_x"
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
         pofile_path = "x_path_x"
         pofile_obj = polib.pofile(pofile=POFILE_CONTENT)
         pofile_obj.metadata.pop("Language", None)
+        pofile_obj.metadata.pop("Language-Django", None)
+        pofile_obj.metadata.pop("Language-Transifex", None)
 
         with mpo(polib.POFile, "save") as mock_pofile_save:
             new_pofile_obj = self.helper.normalize_pofile_language(
+                language_code,
                 transifex_code,
                 resource_slug,
                 resource_name,
@@ -611,6 +621,7 @@ class TestTransifex(TestCase):
         self.assertEqual(new_pofile_obj.metadata["Language"], transifex_code)
 
     def test_noramalize_pofile_language_incorrect(self):
+        language_code = "x_lang_code_x"
         transifex_code = "x_trans_code_x"
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
@@ -619,6 +630,7 @@ class TestTransifex(TestCase):
 
         with mpo(polib.POFile, "save") as mock_pofile_save:
             new_pofile_obj = self.helper.normalize_pofile_language(
+                language_code,
                 transifex_code,
                 resource_slug,
                 resource_name,
@@ -900,6 +912,7 @@ class TestTransifex(TestCase):
 
     def test_normalize_pofile_metadata(self):
         self.helper.dryrun = True
+        language_code = "x_lang_code_x"
         transifex_code = "x_trans_code_x"
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
@@ -908,6 +921,7 @@ class TestTransifex(TestCase):
 
         with mpo(polib.POFile, "save") as mock_pofile_save:
             new_pofile_obj = self.helper.normalize_pofile_metadata(
+                language_code,
                 transifex_code,
                 resource_slug,
                 resource_name,

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -638,7 +638,6 @@ class TransifexHelper:
         pofile_obj.save(pofile_path)
         return pofile_obj
 
-
     def normalize_pofile_metadata(
         self,
         language_code,


### PR DESCRIPTION
## Fixes
Fixes #182
- #182 

## Description
Use locale name for translation directories and add metadata (code)
- Use locale_name instead of language_code for Gettext Files directories
- Add Language-Django and Language-Transifex metadata to Gettext Files (`.po` files)
- Show locale_name in translation stats and improve table layout/display
- Improve PO File data handling / reduce duplication

Corresponding data PR: [Use locale name for translation directories and add metadata (data) by TimidRobot · Pull Request #32 · creativecommons/cc-licenses-data](https://github.com/creativecommons/cc-licenses-data/pull/32)

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
----------------------------------------------------------------------
TOTAL                    1230      2    370      3    99.69%

18 files skipped due to complete coverage.
```

## Screenshots
<img width="1500" alt="Screen Shot 2021-10-14 at 10 25 30" src="https://user-images.githubusercontent.com/691322/137366752-3b0513c1-92cd-4376-9e33-f1d163caab6e.png">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
