### PR TITLE
Improve Deed link language selection and dev display

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -19,11 +19,6 @@ DEFAULT_INPUT_DIR = os.path.dirname(settings.DEEDS_UX_LOCALE_PATH)
 DEFAULT_CSV_FILE = os.path.abspath(
     os.path.realpath(os.path.join(settings.DISTILL_DIR, "transstats.csv"))
 )
-# If something has no language listed, that generally means it's English.
-# We want to set an actual language code on it so that once this data has
-# been imported, we don't have to treat English as a special default.
-DEFAULT_LANGUAGE_CODE = "en"
-
 # The DEFAULT_JURISDICTION_LANGUAGES and JURISDICTION_NAMES are largely based
 # on jurisdictions.rdf in the cc.licenserdf repo.
 # The language codes here are CC language codes, which sometimes differ from

--- a/i18n/utils.py
+++ b/i18n/utils.py
@@ -15,7 +15,6 @@ from django.utils import translation
 # First-party/Local
 from i18n import (
     DEFAULT_JURISDICTION_LANGUAGES,
-    DEFAULT_LANGUAGE_CODE,
     JURISDICTION_NAMES,
     LANGMAP_DJANGO_TO_REDIRECTS,
     LANGMAP_DJANGO_TO_TRANSIFEX,
@@ -309,7 +308,7 @@ def map_legacy_to_django_language_code(legacy_language_code: str) -> str:
 
 
 def get_default_language_for_jurisdiction(
-    jurisdiction_code, default_language=DEFAULT_LANGUAGE_CODE
+    jurisdiction_code, default_language=settings.LANGUAGE_CODE
 ):
     # Input: a jurisdiction code
     # Output: a CC language code

--- a/licenses/management/commands/transstats.py
+++ b/licenses/management/commands/transstats.py
@@ -16,12 +16,7 @@ from django.conf import settings
 from django.core.management import BaseCommand
 
 # First-party/Local
-from i18n import (
-    CSV_HEADERS,
-    DEFAULT_CSV_FILE,
-    DEFAULT_INPUT_DIR,
-    DEFAULT_LANGUAGE_CODE,
-)
+from i18n import CSV_HEADERS, DEFAULT_CSV_FILE, DEFAULT_INPUT_DIR
 from i18n.utils import get_pofile_path, map_django_to_transifex_language_code
 
 LOG = logging.getLogger(__name__)
@@ -54,7 +49,7 @@ def gen_statistics(input_dir, output_file):
         language_code,
         language_data,
     ) in settings.DEEDS_UX_PO_FILE_INFO.items():
-        if language_code == DEFAULT_LANGUAGE_CODE:
+        if language_code == settings.LANGUAGE_CODE:
             continue
         transifex_code = map_django_to_transifex_language_code(language_code)
         pofile_path = get_pofile_path(

--- a/licenses/models.py
+++ b/licenses/models.py
@@ -15,12 +15,12 @@ import posixpath
 
 # Third-party
 import polib
+from django.conf import settings
 from django.db import models
 from django.db.models import Q
 from django.utils import translation
 
 # First-party/Local
-from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import (
     get_default_language_for_jurisdiction,
     get_jurisdiction_name,
@@ -412,10 +412,10 @@ class LegalCode(models.Model):
         return polib.pofile(content.decode(), encoding="utf-8")
 
     def get_english_pofile_path(self) -> str:
-        if self.language_code != DEFAULT_LANGUAGE_CODE:
+        if self.language_code != settings.LANGUAGE_CODE:
             # Same license, just in English translation:
             english_legal_code = self.license.get_legal_code_for_language_code(
-                DEFAULT_LANGUAGE_CODE
+                settings.LANGUAGE_CODE
             )
             return english_legal_code.translation_filename()
         return self.translation_filename()
@@ -680,12 +680,12 @@ class License(models.Model):
     #     # "source" messages and are required if we need to first create the
     #     # resource in Transifex.
     #     en_legal_code = self.get_legal_code_for_language_code(
-    #         DEFAULT_LANGUAGE_CODE
+    #         settings.LANGUAGE_CODE
     #     )
     #     helper = TransifexHelper()
     #     helper.upload_messages_to_transifex(legal_code=en_legal_code)
     #     for legal_code in self.legal_codes.exclude(
-    #         language_code=DEFAULT_LANGUAGE_CODE
+    #         language_code=settings.LANGUAGE_CODE
     #     ):
     #         helper.upload_messages_to_transifex(legal_code=legal_code)
 

--- a/licenses/templates/dev/home.html
+++ b/licenses/templates/dev/home.html
@@ -13,8 +13,8 @@ the generation of static files.
 {% block title %}Dev Home{% endblock %}
 
 {% block content %}
-{% trans "Deed" as deed_translated %}
-{% trans "Legal Code" as legal_code_translated %}
+{% trans "Deed" as deed_label_translated %}
+{% trans "Legal Code" as legal_code_label_translated %}
 
   <style>
     h2, h3, h4 {
@@ -68,11 +68,9 @@ the generation of static files.
                         <th><code>{{ legal_code_group.grouper }}</code></th>
                         {% for legal_code in legal_code_group.list  %}
                           <td>
-                            {% if legal_code.deed_translated %}
-                              <a href="{{ legal_code.deed_url }}">{{ deed_translated }}</a>{% if not legal_code.deed_only %},{% endif %}
-                            {% endif %}
+                            <a href="{{ legal_code.deed_url }}"{% if not legal_code.deed_translated %} style="color: black; font-style: italic;"{% endif %}>{{ deed_label_translated }}</a>{% if not legal_code.deed_only %},{% endif %}
                             {% if not legal_code.deed_only %}
-                              <a href="{{ legal_code.legal_code_url }}">{{ legal_code_translated }}</a>
+                              <a href="{{ legal_code.legal_code_url }}">{{ legal_code_label_translated }}</a>
                             {% endif %}
                           </td>
                         {% endfor %}
@@ -111,10 +109,8 @@ the generation of static files.
                     <th><code>{{ legal_code_group.grouper }}</code></th>
                     {% for legal_code in legal_code_group.list  %}
                       <td>
-                        {% if legal_code.deed_translated %}
-                          <a href="{{ legal_code.deed_url }}">{{ deed_translated }}</a>,
-                        {% endif %}
-                        <a href="{{ legal_code.legal_code_url }}">{{ legal_code_translated }}</a>
+                        <a href="{{ legal_code.deed_url }}"{% if not legal_code.deed_translated %} style="color: black; font-style: italic;"{% endif %}>{{ deed_label_translated }}</a>,
+                        <a href="{{ legal_code.legal_code_url }}">{{ legal_code_label_translated }}</a>
                       </td>
                     {% endfor %}
                   </tr>

--- a/licenses/tests/test_models.py
+++ b/licenses/tests/test_models.py
@@ -3,11 +3,11 @@ from unittest import mock
 
 # Third-party
 import polib
+from django.conf import settings
 from django.test import TestCase, override_settings
 from django.utils.translation import override
 
 # First-party/Local
-from i18n import DEFAULT_LANGUAGE_CODE
 from licenses import FREEDOM_LEVEL_MAX, FREEDOM_LEVEL_MID, FREEDOM_LEVEL_MIN
 from licenses.models import LegalCode, License
 from licenses.tests.factories import (
@@ -226,7 +226,7 @@ class LegalCodeModelTest(TestCase):
             language_code="de",
         )
         legal_code_en = LegalCodeFactory(
-            license=legal_code.license, language_code=DEFAULT_LANGUAGE_CODE
+            license=legal_code.license, language_code=settings.LANGUAGE_CODE
         )
         expected_path = "/some/dir/legalcode/en/LC_MESSAGES/by-sa_40.po"
 
@@ -240,7 +240,7 @@ class LegalCodeModelTest(TestCase):
             self.assertEqual(
                 expected_path, legal_code_en.get_english_pofile_path()
             )
-        mock_glfl.assert_called_with(DEFAULT_LANGUAGE_CODE)
+        mock_glfl.assert_called_with(settings.LANGUAGE_CODE)
 
     @override_settings(DATA_REPOSITORY_DIR="/some/dir")
     def test_get_translation_object(self):
@@ -1044,7 +1044,7 @@ class LicenseModelTest(TestCase):
     #         unit="bx-oh", version="1.3", jurisdiction_code=""
     #     )
     #     self.assertEqual(
-    #         DEFAULT_LANGUAGE_CODE, license.default_language_code()
+    #         settings.LANGUAGE_CODE, license.default_language_code()
     #     )
     #     license = LicenseFactory(
     #         unit="bx-oh", version="1.3", jurisdiction_code="fr"

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 
 # Third-party
 import polib
+from django.conf import settings
 from django.test import TestCase, override_settings
 
 # First-party/Local
-from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import (
     get_pofile_content,
     map_django_to_transifex_language_code,
@@ -416,7 +416,7 @@ class TestTransifex(TestCase):
 
     def test_build_local_data(self):
         license = LicenseFactory(unit="by", version="4.0")
-        LegalCodeFactory(license=license, language_code=DEFAULT_LANGUAGE_CODE)
+        LegalCodeFactory(license=license, language_code=settings.LANGUAGE_CODE)
         LegalCodeFactory(license=license, language_code="de")
         legal_codes = LegalCode.objects.all()
 
@@ -518,7 +518,7 @@ class TestTransifex(TestCase):
 
     def test_add_translation_to_transifex_resource_is_source(self):
         api = self.helper.api
-        language_code = DEFAULT_LANGUAGE_CODE
+        language_code = settings.LANGUAGE_CODE
         resource_slug = "x_slug_x"
         resource_name = "x_name_x"
         pofile_path = "x_path_x"
@@ -1406,7 +1406,7 @@ class TestTransifex(TestCase):
     #     license = LicenseFactory(unit="by-nd", version="4.0")
     #     legal_code = LegalCodeFactory(
     #         license=license,
-    #         language_code=DEFAULT_LANGUAGE_CODE,
+    #         language_code=settings.LANGUAGE_CODE,
     #     )
     #     test_resources = [
     #         {
@@ -1580,10 +1580,10 @@ class TestTransifex(TestCase):
 #         resource_slug = license.resource_slug
 #
 #         # Will need an English legal_code if we need to create the resource
-#         if not resource_exists and language_code != DEFAULT_LANGUAGE_CODE:
+#         if not resource_exists and language_code != settings.LANGUAGE_CODE:
 #             LegalCodeFactory(
 #                 license=license,
-#                 language_code=DEFAULT_LANGUAGE_CODE,
+#                 language_code=settings.LANGUAGE_CODE,
 #             )
 #
 #         # 'timestamp' returns on translation stats from transifex

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -15,7 +15,6 @@ from transifex.api import transifex_api
 
 # First-party/Local
 import licenses.models
-from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import (
     get_pofile_content,
     get_pofile_creation_date,
@@ -164,7 +163,7 @@ class TransifexHelper:
                 f"Transifex {resource_slug} file format is not 'PO'. It is:"
                 f" {i18n_type}"
             )
-        if transifex_code == DEFAULT_LANGUAGE_CODE:
+        if transifex_code == settings.LANGUAGE_CODE:
             # Download source file
             url = self.api.ResourceStringsAsyncDownload.download(
                 resource=resource,
@@ -316,7 +315,7 @@ class TransifexHelper:
         resource_slug = settings.DEEDS_UX_RESOURCE_SLUG
         pofile_path = get_pofile_path(
             locale_or_legalcode="locale",
-            language_code=DEFAULT_LANGUAGE_CODE,
+            language_code=settings.LANGUAGE_CODE,
             translation_domain="django",
         )
         pofile_obj = polib.pofile(pofile_path)
@@ -335,7 +334,7 @@ class TransifexHelper:
             language_code,
             language_data,
         ) in settings.DEEDS_UX_PO_FILE_INFO.items():
-            if language_code == DEFAULT_LANGUAGE_CODE:
+            if language_code == settings.LANGUAGE_CODE:
                 continue
             pofile_path = get_pofile_path(
                 locale_or_legalcode="locale",
@@ -372,7 +371,7 @@ class TransifexHelper:
         for legal_code in legal_codes:
             resource_slug = legal_code.license.resource_slug
             language_code = legal_code.language_code
-            if language_code == DEFAULT_LANGUAGE_CODE:
+            if language_code == settings.LANGUAGE_CODE:
                 continue
             pofile_path = legal_code.translation_filename()
             pofile_obj = polib.pofile(pofile_path)
@@ -466,7 +465,7 @@ class TransifexHelper:
         https://transifex.github.io/openapi/index.html#tag/Resource-Translations
         """
         transifex_code = map_django_to_transifex_language_code(language_code)
-        if language_code == DEFAULT_LANGUAGE_CODE:
+        if language_code == settings.LANGUAGE_CODE:
             raise ValueError(
                 f"{self.nop}{resource_name} ({resource_slug})"
                 f" {transifex_code}: This function,"
@@ -558,7 +557,7 @@ class TransifexHelper:
         pofile_obj,
     ):
         key = "Language-Team"
-        if transifex_code == DEFAULT_LANGUAGE_CODE:
+        if transifex_code == settings.LANGUAGE_CODE:
             translation_team = (
                 f"https://www.transifex.com/{self.organization_slug}/"
                 f"{self.project_slug}/"
@@ -820,7 +819,7 @@ class TransifexHelper:
         legal_codes = (
             licenses.models.LegalCode.objects.valid()
             .translated()
-            .exclude(language_code=DEFAULT_LANGUAGE_CODE)
+            .exclude(language_code=settings.LANGUAGE_CODE)
         )
         repo = git.Repo(settings.DATA_REPOSITORY_DIR)
         if repo.is_dirty():
@@ -831,7 +830,7 @@ class TransifexHelper:
         local_data = self.build_local_data(legal_codes)
         # Resources & Sources
         for resource_slug, resource in local_data.items():
-            language_code = DEFAULT_LANGUAGE_CODE
+            language_code = settings.LANGUAGE_CODE
             transifex_code = map_django_to_transifex_language_code(
                 language_code
             )
@@ -1006,7 +1005,7 @@ class TransifexHelper:
         # legal_codes = (
         #     licenses.models.LegalCode.objects.valid()
         #     .translated()
-        #     .exclude(language_code=DEFAULT_LANGUAGE_CODE)
+        #     .exclude(language_code=settings.LANGUAGE_CODE)
         # )
         # with git.Repo(settings.DATA_REPOSITORY_DIR) as repo:
         #     return (

--- a/licenses/utils.py
+++ b/licenses/utils.py
@@ -13,7 +13,6 @@ from polib import POEntry, POFile
 
 # First-party/Local
 import licenses.models
-from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import (
     get_default_language_for_jurisdiction,
     map_legacy_to_django_language_code,
@@ -163,7 +162,7 @@ def parse_legal_code_filename(filename):
             jurisdiction, ""
         )
     else:
-        language_code = language_code or DEFAULT_LANGUAGE_CODE
+        language_code = language_code or settings.LANGUAGE_CODE
     if not language_code:
         raise ValueError(f"What language? filename={filename}")
     if language_code not in settings.LANG_INFO:

--- a/licenses/views.py
+++ b/licenses/views.py
@@ -16,7 +16,6 @@ from django.template.loader import render_to_string
 from django.utils import translation
 
 # First-party/Local
-from i18n import DEFAULT_LANGUAGE_CODE
 from i18n.utils import (
     active_translation,
     get_default_language_for_jurisdiction,
@@ -134,10 +133,16 @@ def get_deed_rel_path(
 ):
     deed_rel_path = os.path.relpath(deed_url, path_start)
     if language_code not in settings.LANGUAGES_MOSTLY_TRANSLATED:
-        deed_rel_path = deed_rel_path.replace(
-            f"deed.{language_code}",
-            f"deed.{language_default}",
-        )
+        if language_default in settings.LANGUAGES_MOSTLY_TRANSLATED:
+            # Translation incomplete, use region default language
+            deed_rel_path = deed_rel_path.replace(
+                f"deed.{language_code}", f"deed.{language_default}"
+            )
+        else:
+            # Translation incomplete, use Englishi
+            deed_rel_path = deed_rel_path.replace(
+                f"deed.{language_code}", f"deed.{settings.LANGUAGE_CODE}"
+            )
     return deed_rel_path
 
 
@@ -150,7 +155,7 @@ def name_local(legal_code):
 def normalize_path_and_lang(request_path, jurisdiction, language_code):
     if not language_code:
         language_code = get_default_language_for_jurisdiction(
-            jurisdiction, DEFAULT_LANGUAGE_CODE
+            jurisdiction, settings.LANGUAGE_CODE
         )
     if not request_path.endswith(f".{language_code}"):
         request_path = f"{request_path}.{language_code}"


### PR DESCRIPTION
## Description
Improve Deed link language selection and dev display
- replace use of redundant `i18n.DEFAULT_LANGUAGE_CODE` with `settings.LANGUAGE_CODE`
- improve Deed language selection
  - old: translation (`language_code`) => region default (`language_default`)
  - new:translation (`language_code`) => region default (`language_default`) => default language ( `settings.LANGUAGE_CODE``
- improve Deed display on dev home page

Related data PR: 

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
----------------------------------------------------------------------
TOTAL                    1200      2    388      3    99.69%

18 files skipped due to complete coverage.
```

## Screenshots

### Old/main
<img width="918" alt="Screen Shot 2021-10-20 at 11 25 47" src="https://user-images.githubusercontent.com/691322/138150064-7a710598-3210-40a4-b8fd-cbc974f16b73.png">

### New/PR
<img width="934" alt="Screen Shot 2021-10-20 at 08 49 11" src="https://user-images.githubusercontent.com/691322/138147679-acf35f12-35a7-41a3-9bc2-7fc5148c618a.png">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
