### PR TITLE
Compare translations

### DIFF
--- a/licenses/management/commands/compare_translations.py
+++ b/licenses/management/commands/compare_translations.py
@@ -1,0 +1,76 @@
+# Standard library
+import logging
+from argparse import ArgumentParser
+
+# Third-party
+from django.conf.locale import LANG_INFO
+from django.core.management import BaseCommand, CommandError
+from git.exc import GitCommandError, RepositoryDirtyError
+from requests.exceptions import HTTPError
+
+# First-party/Local
+from licenses.transifex import TransifexHelper
+
+LOG = logging.getLogger(__name__)
+LOG_LEVELS = {
+    0: logging.ERROR,
+    1: logging.WARNING,
+    2: logging.INFO,
+    3: logging.DEBUG,
+}
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser: ArgumentParser):
+        parser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            help="force a string comparison even if dates and counts match",
+        )
+        limit_domain = parser.add_mutually_exclusive_group()
+        limit_domain.add_argument(
+            "--deeds-ux",
+            "--deedsux",
+            action="store_true",
+            help="limit translation domain to Deeds & UX",
+        )
+        limit_domain.add_argument(
+            "--legal-code",
+            "--legalcode",
+            action="store_true",
+            help="limit translation domains to Legal Codes",
+        )
+        parser.add_argument(
+            "-l",
+            "--language",
+            action="store",
+            help="limit translation language to specified Language Code",
+        )
+
+    def main(self, **options):
+        if options["deeds_ux"]:
+            limit_domain = "deeds_ux"
+        elif options["legal_code"]:
+            limit_domain = "legal_code"
+        else:
+            limit_domain = None
+        limit_language = options["language"]
+        if limit_language is not None and limit_language not in LANG_INFO:
+            raise CommandError(f"Invalid language code: {limit_language}")
+        colordiff = True
+        LOG.setLevel(LOG_LEVELS[int(options["verbosity"])])
+        transifex = TransifexHelper(dryrun=True, logger=LOG)
+        transifex.compare_translations(
+            limit_domain, limit_language, options["force"], colordiff
+        )
+
+    def handle(self, **options):
+        try:
+            self.main(**options)
+        except GitCommandError as e:
+            raise CommandError(f"GitCommandError: {e}")
+        except HTTPError as e:
+            raise CommandError(f"HTTPError: {e}")
+        except RepositoryDirtyError as e:
+            raise CommandError(f"RepositoryDirtyError: {e}")

--- a/licenses/management/commands/normalize_translations.py
+++ b/licenses/management/commands/normalize_translations.py
@@ -33,13 +33,13 @@ class Command(BaseCommand):
             "--deeds-ux",
             "--deedsux",
             action="store_true",
-            help="limit translation domain normalization to Deeds & UX",
+            help="limit translation domain to Deeds & UX",
         )
         limit_domain.add_argument(
             "--legal-code",
             "--legalcode",
             action="store_true",
-            help="limit translation domain normalization to Legal Codes",
+            help="limit translation domains to Legal Codes",
         )
         parser.add_argument(
             "-l",


### PR DESCRIPTION
## Description
Compare translations:
- Provide command to view translation diffs so that appropriate action can be taken (sync, push, pull [actions not yet coded]).

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
----------------------------------------------------------------------
TOTAL                    1292      2    438      3    99.71%

18 files skipped due to complete coverage.
```

## Screenshots
```
docker-compose exec app ./manage.py compare_translations -v2 --deeds-ux -l ja
```
<img width="719" alt="Screen Shot 2021-11-01 at 07 14 59" src="https://user-images.githubusercontent.com/691322/139685904-a8469bd0-b805-4943-ab31-c4c88294b3c1.png">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
