### PR TITLE
Transifex sync and pull (code)

### DIFF
--- a/licenses/management/commands/normalize_translations.py
+++ b/licenses/management/commands/normalize_translations.py
@@ -30,6 +30,12 @@ class Command(BaseCommand):
         )
         limit_domain = parser.add_mutually_exclusive_group()
         limit_domain.add_argument(
+            "-d",
+            "--domain",
+            action="store",
+            help="limit translation domain to specified domain",
+        )
+        limit_domain.add_argument(
             "--deeds-ux",
             "--deedsux",
             action="store_true",
@@ -54,7 +60,7 @@ class Command(BaseCommand):
         elif options["legal_code"]:
             limit_domain = "legal_code"
         else:
-            limit_domain = None
+            limit_domain = options["domain"]
         limit_language = options["language"]
         if limit_language is not None and limit_language not in LANG_INFO:
             raise CommandError(f"Invalid language code: {limit_language}")

--- a/licenses/management/commands/pull_translation.py
+++ b/licenses/management/commands/pull_translation.py
@@ -23,53 +23,32 @@ LOG_LEVELS = {
 class Command(BaseCommand):
     def add_arguments(self, parser: ArgumentParser):
         parser.add_argument(
-            "-f",
-            "--force",
+            "-n",
+            "--dryrun",
             action="store_true",
-            help="force a string comparison even if dates and counts match",
+            help="dry run: do not make any changes",
         )
-        limit_domain = parser.add_mutually_exclusive_group()
-        limit_domain.add_argument(
+        parser.add_argument(
             "-d",
             "--domain",
             action="store",
+            required=True,
             help="limit translation domain to specified domain",
-        )
-        limit_domain.add_argument(
-            "--deeds-ux",
-            "--deedsux",
-            action="store_true",
-            help="limit translation domain to Deeds & UX",
-        )
-        limit_domain.add_argument(
-            "--legal-code",
-            "--legalcode",
-            action="store_true",
-            help="limit translation domains to Legal Codes",
         )
         parser.add_argument(
             "-l",
             "--language",
             action="store",
+            required=True,
             help="limit translation language to specified Language Code",
         )
 
     def main(self, **options):
-        if options["deeds_ux"]:
-            limit_domain = "deeds_ux"
-        elif options["legal_code"]:
-            limit_domain = "legal_code"
-        else:
-            limit_domain = options["domain"]
-        limit_language = options["language"]
-        if limit_language is not None and limit_language not in LANG_INFO:
-            raise CommandError(f"Invalid language code: {limit_language}")
-        colordiff = True
+        if options["language"] not in LANG_INFO:
+            raise CommandError(f"Invalid language code: {options['language']}")
         LOG.setLevel(LOG_LEVELS[int(options["verbosity"])])
-        transifex = TransifexHelper(dryrun=True, logger=LOG)
-        transifex.compare_translations(
-            limit_domain, limit_language, options["force"], colordiff
-        )
+        transifex = TransifexHelper(dryrun=options["dryrun"], logger=LOG)
+        transifex.pull_translation(options["domain"], options["language"])
 
     def handle(self, **options):
         try:

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -1107,7 +1107,7 @@ class TestTransifex(TestCase):
         transifex_revision = pofile_revision
         transifex_translated = pofile_translated
 
-        with self.assertLogs(self.helper.log) as log_context:
+        with self.assertLogs(self.helper.log, level="DEBUG") as log_context:
             result = self.helper.translations_metadata_identical(
                 transifex_code,
                 resource_slug,
@@ -1121,7 +1121,7 @@ class TestTransifex(TestCase):
                 transifex_translated,
             )
 
-        self.assertTrue(log_context.output[0].startswith("INFO:"))
+        self.assertTrue(log_context.output[0].startswith("DEBUG:"))
         self.assertNotIn("creation:", log_context.output[0])
         self.assertNotIn("revision:", log_context.output[0])
         self.assertNotIn("translated entries:", log_context.output[0])

--- a/licenses/tests/test_transifex.py
+++ b/licenses/tests/test_transifex.py
@@ -937,7 +937,7 @@ class TestTransifex(TestCase):
         transifex_revision = pofile_revision
         transifex_string_count = pofile_string_count
 
-        with self.assertLogs(self.helper.log) as log_context:
+        with self.assertLogs(self.helper.log, level="DEBUG") as log_context:
             result = self.helper.resources_metadata_identical(
                 transifex_code,
                 resource_slug,
@@ -951,7 +951,7 @@ class TestTransifex(TestCase):
                 transifex_string_count,
             )
 
-        self.assertTrue(log_context.output[0].startswith("INFO:"))
+        self.assertTrue(log_context.output[0].startswith("DEBUG:"))
         self.assertNotIn("creation:", log_context.output[0])
         self.assertNotIn("revision:", log_context.output[0])
         self.assertNotIn("string count:", log_context.output[0])

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -868,10 +868,6 @@ class TransifexHelper:
         resource_name,
         pofile_path,
         pofile_obj,
-        pofile_creation,
-        pofile_revision,
-        transifex_creation,
-        transifex_revision,
     ):
         transifex_pofile_content = self.transifex_get_pofile_content(
             resource_slug, transifex_code
@@ -1303,10 +1299,6 @@ class TransifexHelper:
                         resource_name,
                         pofile_path,
                         pofile_obj,
-                        pofile_creation,
-                        pofile_revision,
-                        transifex_creation,
-                        transifex_revision,
                     )
 
                 # Normalize Creation and Revision dates in local PO File

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -723,15 +723,9 @@ class TransifexHelper:
                 pofile=transifex_pofile_content.decode(), encoding="utf-8"
             )
             po_entries_are_the_same = True
-            for index, entry in enumerate(pofile_obj):
-                if pofile_obj[index] != transifex_pofile_obj[index]:
+            for index, pofile_entry in enumerate(pofile_obj):
+                if pofile_entry != transifex_pofile_obj[index]:
                     po_entries_are_the_same = False
-                    # self.log.debug(
-                    # "\n=== Local =======\n"
-                    # f"{pofile_obj[index]}"
-                    # "\n=== Transifex ===\n"
-                    # f"{transifex_pofile_obj[index]}"
-                    # )
                     break
             if po_entries_are_the_same:
                 # Normalize Local PO File revision date if the Local PO File
@@ -776,6 +770,243 @@ class TransifexHelper:
 
         return pofile_obj
 
+    def resources_metadata_identical(
+        self,
+        transifex_code,
+        resource_slug,
+        resource_name,
+        pofile_path,
+        pofile_creation,
+        pofile_revision,
+        pofile_string_count,
+        transifex_creation,
+        transifex_revision,
+        transifex_string_count,
+    ):
+        differ = []
+        if pofile_creation != transifex_creation:
+            differ.append(
+                f"\n    PO File creation:   {pofile_creation}"
+                f"\n    Transifex creation: {transifex_creation}"
+            )
+        if pofile_revision != transifex_revision:
+            differ.append(
+                f"\n    PO File revision:   {pofile_revision}"
+                f"\n    Transifex revision: {transifex_revision}"
+            )
+        if pofile_string_count != transifex_string_count:
+            differ.append(
+                f"\n    PO File string count:   {pofile_string_count:>4}"
+                f"\n    Transifex string count: {transifex_string_count:>4}"
+            )
+        if differ:
+            differ = "".join(differ)
+            self.log.error(
+                f"{self.nop}{resource_name} ({resource_slug})"
+                f" {transifex_code}: Resources differ:"
+                f"\n  PO File path: {pofile_path}{differ}"
+            )
+            return False
+        else:
+            self.log.info(
+                f"{self.nop}{resource_name} ({resource_slug})"
+                f" {transifex_code}: Resources appear to be identical"
+                " based on metadata"
+            )
+            return True
+
+    def translations_metadata_identical(
+        self,
+        transifex_code,
+        resource_slug,
+        resource_name,
+        pofile_path,
+        pofile_creation,
+        pofile_revision,
+        pofile_translated,
+        transifex_creation,
+        transifex_revision,
+        transifex_translated,
+    ):
+        differ = []
+        if pofile_creation != transifex_creation:
+            differ.append(
+                f"\n    PO File creation:   {pofile_creation}"
+                f"\n    Transifex creation: {transifex_creation}"
+            )
+        if pofile_revision != transifex_revision:
+            differ.append(
+                f"\n    PO File revision:   {pofile_revision}"
+                f"\n    Transifex revision: {transifex_revision}"
+            )
+        if pofile_translated != transifex_translated:
+            differ.append(
+                f"\n    PO File translated entries:   {pofile_translated:>4}"
+                f"\n    Transifex translated entries:"
+                f" {transifex_translated:>4}"
+            )
+        if differ:
+            differ = "".join(differ)
+            self.log.error(
+                f"{self.nop}{resource_name} ({resource_slug})"
+                f" {transifex_code}: Translations differ:"
+                f"\n  PO File path: {pofile_path}{differ}"
+            )
+            return False
+        else:
+            self.log.info(
+                f"{self.nop}{resource_name} ({resource_slug})"
+                f" {transifex_code}: Translations appear to be identical"
+                " based on metadata"
+            )
+            return True
+
+    def safesync_pofile(
+        self,
+        transifex_code,
+        resource_slug,
+        resource_name,
+        pofile_path,
+        pofile_obj,
+        pofile_creation,
+        pofile_revision,
+        transifex_creation,
+        transifex_revision,
+    ):
+        transifex_pofile_content = self.transifex_get_pofile_content(
+            resource_slug, transifex_code
+        )
+        transifex_pofile_obj = polib.pofile(
+            pofile=transifex_pofile_content.decode(), encoding="utf-8"
+        )
+        changes = []
+        for index, entry in enumerate(pofile_obj):
+            pofile_entry = entry
+            transifex_entry = transifex_pofile_obj[index]
+            if pofile_entry != transifex_entry:
+                if pofile_entry.msgid != transifex_entry.msgid:
+                    continue
+                if (
+                    pofile_entry.msgstr is not None
+                    and pofile_entry.msgstr != ""
+                ):
+                    continue
+                if len(pofile_entry.msgid) > 65:
+                    msgid = f"{pofile_entry.msgid[:62]}..."
+                else:
+                    msgid = pofile_entry.msgid
+                changes.append(f"msgid {index:>4}: '{msgid}'")
+                if not self.dryrun:
+                    pofile_entry.msgstr = transifex_entry.msgstr
+        if changes:
+            changes = "\n  ".join(changes)
+            self.log.info(
+                f"{self.nop}Adding translation from Transifex to PO File:\n"
+                f"  {changes}"
+            )
+            if not self.dryrun:
+                pofile_obj.save(pofile_path)
+        return pofile_obj
+
+    def diff_entry(
+        self,
+        transifex_code,
+        resource_slug,
+        resource_name,
+        pofile_path,
+        pofile_entry,
+        transifex_entry,
+        colordiff=False,
+    ):
+        """Display entries as a colorized unified diff."""
+        diff = list(
+            difflib.unified_diff(
+                str(pofile_entry).split("\n"),
+                str(transifex_entry).split("\n"),
+                fromfile=f"{resource_name} PO File {pofile_path}",
+                tofile=(
+                    f"{resource_name} Transifex {resource_slug}"
+                    f" {transifex_code}"
+                ),
+                # Number of lines of context (n) is set very high to ensure
+                # that the all comments and the entire msgid are shown
+                n=999,
+            )
+        )
+        if colordiff:  # pragma: no cover
+            rst = "\033[0m"
+            for i, line in enumerate(diff):
+                if line.startswith("---"):
+                    diff[i] = f"\033[91m{line.rstrip()}{rst}"
+                elif line.startswith("+++"):
+                    diff[i] = f"\033[92m{line.rstrip()}{rst}"
+                elif line.startswith("@"):
+                    diff[i] = f"\033[36m{line.rstrip()}{rst}"
+                elif line.startswith("-"):
+                    diff[i] = f"\033[31m{line}{rst}"
+                elif line.startswith("+"):
+                    diff[i] = f"\033[32m{line}{rst}"
+                else:
+                    diff[i] = f"\033[90m{line}{rst}"
+        diff = "\n".join(diff)
+        self.log.warn(f"\n{diff}")
+
+    def diff_translations(
+        self,
+        transifex_code,
+        resource_slug,
+        resource_name,
+        pofile_path,
+        pofile_obj,
+        colordiff,
+    ):
+        transifex_pofile_content = self.transifex_get_pofile_content(
+            resource_slug, transifex_code
+        )
+        transifex_pofile_obj = polib.pofile(
+            pofile=transifex_pofile_content.decode(), encoding="utf-8"
+        )
+        for index, entry in enumerate(pofile_obj):
+            pofile_entry = entry
+            transifex_entry = transifex_pofile_obj[index]
+            if pofile_entry != transifex_entry:
+                self.diff_entry(
+                    transifex_code,
+                    resource_slug,
+                    resource_name,
+                    pofile_path,
+                    pofile_entry,
+                    transifex_entry,
+                    colordiff,
+                )
+
+    def save_transifex_to_pofile(
+        self,
+        resource_slug,
+        language_code,
+        transifex_code,
+        pofile_path,
+        pofile_obj,
+    ):
+        # Get Transifex PO File
+        transifex_pofile_content = self.transifex_get_pofile_content(
+            resource_slug, transifex_code
+        )
+        transifex_obj = polib.pofile(
+            pofile=transifex_pofile_content.decode(), encoding="utf-8"
+        )
+
+        # Overrite local PO File
+        self.log.info(
+            f"{self.nop}{resource_slug} {language_code} ({transifex_code}):"
+            " overwriting local translation with Transifex translation:"
+            f" {pofile_path}"
+        )
+        pofile_obj = transifex_obj
+        if not self.dryrun:
+            pofile_obj.save(pofile_path)
+        return pofile_obj
+
     def check_data_repo_is_clean(self, repo=None):
         if not repo:
             repo = git.Repo(settings.DATA_REPOSITORY_DIR)
@@ -785,28 +1016,64 @@ class TransifexHelper:
         return True
 
     def get_local_data(self, limit_domain, limit_language):
+        self.log.debug(
+            f"limit_domain: {limit_domain}, limit_language: {limit_language}"
+        )
+
+        # Deeds & UX
         deeds_ux = {}
         if not limit_domain or limit_domain == "deeds_ux":
             deeds_ux = settings.DEEDS_UX_PO_FILE_INFO
+            if limit_language:
+                deeds_ux = {limit_language: deeds_ux[limit_language]}
 
-        legal_codes = []
-        if not limit_domain or limit_domain == "legal_code":
-            legal_codes = list(
+        # Legal Codes
+        valid_domains = []
+        if limit_domain and limit_domain != "deeds_ux":
+            for legal_code in (
                 licenses.models.LegalCode.objects.valid()
                 .translated()
-                .exclude(language_code=settings.LANGUAGE_CODE)
+                .filter(language_code=settings.LANGUAGE_CODE)
+            ):
+                valid_domains.append(legal_code.translation_domain)
+            valid_domains = sorted(list(set(valid_domains)))
+            self.log.debug(
+                f"valid legal code translation domains: {valid_domains}"
             )
+        legal_codes = []
+        if (
+            not limit_domain
+            or limit_domain == "legal_code"
+            or limit_domain in valid_domains
+        ):
+            if limit_language:
+                legal_codes = list(
+                    licenses.models.LegalCode.objects.valid()
+                    .translated()
+                    .exclude(language_code=settings.LANGUAGE_CODE)
+                    .filter(language_code=limit_language)
+                )
+            else:
+                legal_codes = list(
+                    licenses.models.LegalCode.objects.valid()
+                    .translated()
+                    .exclude(language_code=settings.LANGUAGE_CODE)
+                )
+        if limit_domain and limit_domain in valid_domains:
+            legal_codes_selected = []
+            for legal_code in legal_codes:
+                if limit_domain == legal_code.translation_domain:
+                    legal_codes_selected.append(legal_code)
+            legal_codes = legal_codes_selected
 
-        local_data = self.build_local_data(
-            deeds_ux, legal_codes, limit_language
-        )
+        # Build local data and return
+        local_data = self.build_local_data(deeds_ux, legal_codes)
         return local_data
 
     def build_local_data(
         self,
         deeds_ux: dict,
         legal_codes: Iterable["licenses.models.LegalCode"],
-        limit_language,
     ):
         local_data = {}
 
@@ -837,8 +1104,6 @@ class TransifexHelper:
             language_data,
         ) in deeds_ux.items():
             if language_code == settings.LANGUAGE_CODE:
-                continue
-            if limit_language and limit_language != language_code:
                 continue
             pofile_path = get_pofile_path(
                 locale_or_legalcode="locale",
@@ -879,8 +1144,6 @@ class TransifexHelper:
             resource_slug = legal_code.license.resource_slug
             language_code = legal_code.language_code
             if language_code == settings.LANGUAGE_CODE:
-                continue
-            if limit_language and limit_language != language_code:
                 continue
             pofile_path = legal_code.translation_filename()
             pofile_obj = polib.pofile(pofile_path)
@@ -985,6 +1248,9 @@ class TransifexHelper:
                 )
                 pofile_path = translation["pofile_path"]
                 pofile_obj = translation["pofile_obj"]
+                pofile_creation = translation["creation_date"]
+                pofile_revision = translation["revision_date"]
+                pofile_translated = len(pofile_obj.translated_entries())
 
                 # Normalize deterministic metadata
                 pofile_obj = self.normalize_pofile_metadata(
@@ -1015,8 +1281,35 @@ class TransifexHelper:
                 transifex_revision = parse_date(
                     t_stats["last_translation_update"]
                 )
+                transifex_translated = t_stats["translated_strings"]
 
-                # Normalize Creation and Revision dates in local PO files
+                # Compare metadata
+                if not self.translations_metadata_identical(
+                    transifex_code,
+                    resource_slug,
+                    resource_name,
+                    pofile_path,
+                    pofile_creation,
+                    pofile_revision,
+                    pofile_translated,
+                    transifex_creation,
+                    transifex_revision,
+                    transifex_translated,
+                ):
+                    # Add missing translations to local PO File
+                    pofile_obj = self.safesync_pofile(
+                        transifex_code,
+                        resource_slug,
+                        resource_name,
+                        pofile_path,
+                        pofile_obj,
+                        pofile_creation,
+                        pofile_revision,
+                        transifex_creation,
+                        transifex_revision,
+                    )
+
+                # Normalize Creation and Revision dates in local PO File
                 pofile_obj = self.normalize_pofile_dates(
                     transifex_code,
                     resource_slug,
@@ -1027,169 +1320,6 @@ class TransifexHelper:
                     pofile_revision,
                     transifex_creation,
                     transifex_revision,
-                )
-
-    def resources_metadata_identical(
-        self,
-        transifex_code,
-        resource_slug,
-        resource_name,
-        pofile_path,
-        pofile_creation,
-        pofile_revision,
-        pofile_string_count,
-        transifex_creation,
-        transifex_revision,
-        transifex_string_count,
-    ):
-        differ = []
-        if pofile_creation != transifex_creation:
-            differ.append(
-                f"\n    PO File creation:   {pofile_creation}"
-                f"\n    Transifex creation: {transifex_creation}"
-            )
-        if pofile_revision != transifex_revision:
-            differ.append(
-                f"\n    PO File revision:   {pofile_revision}"
-                f"\n    Transifex revision: {transifex_revision}"
-            )
-        if pofile_string_count != transifex_string_count:
-            differ.append(
-                f"\n    PO File string count:   {pofile_string_count:>4}"
-                f"\n    Transifex string count: {transifex_string_count:>4}"
-            )
-        if differ:
-            differ = "".join(differ)
-            self.log.error(
-                f"{self.nop}{resource_name} ({resource_slug})"
-                f" {transifex_code}: Resources differ:"
-                f"\n  PO File path: {pofile_path}{differ}"
-            )
-            return False
-        else:
-            self.log.info(
-                f"{self.nop}{resource_name} ({resource_slug})"
-                f" {transifex_code}: Resources appear to be identical"
-                " based on metadata"
-            )
-            return True
-
-    def translations_metadata_identical(
-        self,
-        transifex_code,
-        resource_slug,
-        resource_name,
-        pofile_path,
-        pofile_creation,
-        pofile_revision,
-        pofile_translated,
-        transifex_creation,
-        transifex_revision,
-        transifex_translated,
-    ):
-        differ = []
-        if pofile_creation != transifex_creation:
-            differ.append(
-                f"\n    PO File creation:   {pofile_creation}"
-                f"\n    Transifex creation: {transifex_creation}"
-            )
-        if pofile_revision != transifex_revision:
-            differ.append(
-                f"\n    PO File revision:   {pofile_revision}"
-                f"\n    Transifex revision: {transifex_revision}"
-            )
-        if pofile_translated != transifex_translated:
-            differ.append(
-                f"\n    PO File translated entries:   {pofile_translated:>4}"
-                f"\n    Transifex translated entries:"
-                f" {transifex_translated:>4}"
-            )
-        if differ:
-            differ = "".join(differ)
-            self.log.error(
-                f"{self.nop}{resource_name} ({resource_slug})"
-                f" {transifex_code}: Translations differ:"
-                f"\n  PO File path: {pofile_path}{differ}"
-            )
-            return False
-        else:
-            self.log.info(
-                f"{self.nop}{resource_name} ({resource_slug})"
-                f" {transifex_code}: Translations appear to be identical"
-                " based on metadata"
-            )
-            return True
-
-    def diff_entry(
-        self,
-        transifex_code,
-        resource_slug,
-        resource_name,
-        pofile_path,
-        pofile_entry,
-        transifex_entry,
-        colordiff=False,
-    ):
-        """Display entries as a colorized unified diff."""
-        diff = list(
-            difflib.unified_diff(
-                str(pofile_entry).split("\n"),
-                str(transifex_entry).split("\n"),
-                fromfile=f"{resource_name} PO File {pofile_path}",
-                tofile=(
-                    f"{resource_name} Transifex {resource_slug}"
-                    f" {transifex_code}"
-                ),
-                # Number of lines of context (n) is set very high to ensure
-                # that the all comments and the entire msgid are shown
-                n=999,
-            )
-        )
-        if colordiff:  # pragma: no cover
-            rst = "\033[0m"
-            for i, line in enumerate(diff):
-                if line.startswith("---"):
-                    diff[i] = f"\033[91m{line.rstrip()}{rst}"
-                elif line.startswith("+++"):
-                    diff[i] = f"\033[92m{line.rstrip()}{rst}"
-                elif line.startswith("@"):
-                    diff[i] = f"\033[36m{line.rstrip()}{rst}"
-                elif line.startswith("-"):
-                    diff[i] = f"\033[31m{line}{rst}"
-                elif line.startswith("+"):
-                    diff[i] = f"\033[32m{line}{rst}"
-                else:
-                    diff[i] = f"\033[90m{line}{rst}"
-        diff = "\n".join(diff)
-        self.log.warn(f"\n{diff}")
-
-    def diff_translations(
-        self,
-        transifex_code,
-        resource_slug,
-        resource_name,
-        pofile_path,
-        pofile_obj,
-        colordiff,
-    ):
-        transifex_pofile_content = self.transifex_get_pofile_content(
-            resource_slug, transifex_code
-        )
-        transifex_pofile_obj = polib.pofile(
-            pofile=transifex_pofile_content.decode(), encoding="utf-8"
-        )
-        for index, entry in enumerate(pofile_obj):
-            pofile_entry = entry
-            transifex_entry = transifex_pofile_obj[index]
-            if pofile_entry != transifex_entry:
-                self.diff_entry(
-                    transifex_code,
-                    resource_slug,
-                    resource_name,
-                    pofile_path,
-                    pofile_entry,
-                    transifex_entry,
-                    colordiff,
                 )
 
     def compare_translations(
@@ -1283,6 +1413,44 @@ class TransifexHelper:
                         pofile_obj,
                         colordiff,
                     )
+
+    def pull_translation(
+        self, limit_domain, limit_language
+    ):  # pragma: no cover
+        self.check_data_repo_is_clean()
+        local_data = self.get_local_data(limit_domain, limit_language)
+
+        # Resources & Sources
+        for resource_slug, resource in local_data.items():
+            resource_name = resource["name"]
+
+            if not self.resource_present(resource_slug, resource_name):
+                continue
+
+            # Translations
+            for language_code, translation in resource["translations"].items():
+                transifex_code = map_django_to_transifex_language_code(
+                    language_code
+                )
+                pofile_path = translation["pofile_path"]
+                pofile_obj = translation["pofile_obj"]
+
+                if not self.translation_supported(
+                    resource_slug, resource_name, transifex_code
+                ):
+                    continue
+
+                pofile_obj = self.save_transifex_to_pofile(
+                    resource_slug,
+                    language_code,
+                    transifex_code,
+                    pofile_path,
+                    pofile_obj,
+                )
+
+        # Normalize newly updated local PO File
+        if not self.dryrun:
+            self.normalize_translations(limit_domain, limit_language)
 
     def check_for_translation_updates_with_repo_and_legal_codes(
         self,

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -809,7 +809,7 @@ class TransifexHelper:
             )
             return False
         else:
-            self.log.info(
+            self.log.debug(
                 f"{self.nop}{resource_name} ({resource_slug})"
                 f" {transifex_code}: Resources appear to be identical"
                 " based on metadata"

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -657,8 +657,8 @@ class TransifexHelper:
         self.log.info(
             f"{self.nop}{resource_name} ({resource_slug}) {transifex_code}:"
             " Correcting PO file 'PO-Revision-Date' to match Transifex:"
-            f"\n{label:>{pad}}: {transifex_revision}"
             f"\n{pofile_path}: {pofile_revision}"
+            f"\n{label:>{pad}}: {transifex_revision}"
         )
         if self.dryrun:
             return pofile_obj
@@ -998,10 +998,9 @@ class TransifexHelper:
             " overwriting local translation with Transifex translation:"
             f" {pofile_path}"
         )
-        pofile_obj = transifex_obj
         if not self.dryrun:
-            pofile_obj.save(pofile_path)
-        return pofile_obj
+            transifex_obj.save(pofile_path)
+        return transifex_obj
 
     def check_data_repo_is_clean(self, repo=None):
         if not repo:

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -20,6 +20,7 @@ from i18n.utils import (
     get_pofile_creation_date,
     get_pofile_path,
     get_pofile_revision_date,
+    load_deeds_ux_translations,
     map_django_to_transifex_language_code,
     parse_date,
 )
@@ -1441,6 +1442,8 @@ class TransifexHelper:
 
         # Normalize newly updated local PO File
         if not self.dryrun:
+            if limit_domain and limit_domain == "deeds_ux":
+                load_deeds_ux_translations()
             self.normalize_translations(limit_domain, limit_language)
 
     def check_for_translation_updates_with_repo_and_legal_codes(

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -855,7 +855,7 @@ class TransifexHelper:
             )
             return False
         else:
-            self.log.info(
+            self.log.debug(
                 f"{self.nop}{resource_name} ({resource_slug})"
                 f" {transifex_code}: Translations appear to be identical"
                 " based on metadata"

--- a/licenses/transifex.py
+++ b/licenses/transifex.py
@@ -883,9 +883,9 @@ class TransifexHelper:
             if pofile_entry != transifex_entry:
                 # Prep msgids for display
                 if len(pofile_entry.msgid) > 60:  # pragma: no cover
-                    l_msgid = f"{pofile_entry.msgid[:62]}..."
+                    p_msgid = f"{pofile_entry.msgid[:62]}..."
                 else:  # pragma: no cover
-                    l_msgid = pofile_entry.msgid
+                    p_msgid = pofile_entry.msgid
                 if len(pofile_entry.msgid) > 60:  # pragma: no cover
                     t_msgid = f"{transifex_entry.msgid[:62]}..."
                 else:  # pragma: no cover
@@ -897,8 +897,8 @@ class TransifexHelper:
                         f"{self.nop}{resource_slug} {language_code}"
                         f" ({transifex_code}) Local PO File msgid and"
                         " Transifex msgid do not match:"
-                        "\n    PO File: '{t_msgid}'"
-                        "\n  Transifex: '{t_msgid}'"
+                        f"\n    PO File: '{p_msgid}'"
+                        f"\n  Transifex: '{t_msgid}'"
                     )
                     continue
 
@@ -911,7 +911,7 @@ class TransifexHelper:
                     continue
 
                 # Add missing translation
-                changes.append(f"msgid {index:>4}: '{l_msgid}'")
+                changes.append(f"msgid {index:>4}: '{p_msgid}'")
                 if not self.dryrun:
                     pofile_entry.msgstr = transifex_entry.msgstr
 


### PR DESCRIPTION
## Description
Improve Transifex integration with "safesync" and "pull"
- Add "safesync" to `normalize_translations` management command--if an entry is empty locally, but a translation exists on Transifex, use it
- Add `pull_translation` management command--overwrite local data with Transifex data
- Improve command line option support of translation domains

see related data PR: [Transifex sync and pull (data) by TimidRobot · Pull Request #41 · creativecommons/cc-licenses-data](https://github.com/creativecommons/cc-licenses-data/pull/41)

## Tests
```
Name                    Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------
licenses/git_utils.py      83      2     36      3    95.80%   70->exit, 90-92, 124->126, 140->145
----------------------------------------------------------------------
TOTAL                    1308      2    448      3    99.72%

18 files skipped due to complete coverage.
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
